### PR TITLE
Make grammar scope more specific

### DIFF
--- a/git_gutter.py
+++ b/git_gutter.py
@@ -52,24 +52,24 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
 
     def lines_removed_top(self, lines):
         regions = self.lines_to_regions(lines)
-        scope = 'markup.deleted'
+        scope = 'markup.deleted.git_gutter'
         icon = '../GitGutter/icons/deleted_top'
         self.view.add_regions('git_gutter_deleted_top', regions, scope, icon)
 
     def lines_removed_bottom(self, lines):
         regions = self.lines_to_regions(lines)
-        scope = 'markup.deleted'
+        scope = 'markup.deleted.git_gutter'
         icon = '../GitGutter/icons/deleted_bottom'
         self.view.add_regions('git_gutter_deleted_bottom', regions, scope, icon)
 
     def lines_added(self, lines):
         regions = self.lines_to_regions(lines)
-        scope = 'markup.inserted'
+        scope = 'markup.inserted.git_gutter'
         icon = '../GitGutter/icons/inserted'
         self.view.add_regions('git_gutter_inserted', regions, scope, icon)
 
     def lines_modified(self, lines):
         regions = self.lines_to_regions(lines)
-        scope = 'markup.changed'
+        scope = 'markup.changed.git_gutter'
         icon = '../GitGutter/icons/changed'
         self.view.add_regions('git_gutter_changed', regions, scope, icon)


### PR DESCRIPTION
By updating the scope to use `markup.deleted.git_gutter` instead of `markup.deleted` it allows greater customization for this plugin.

For example my default diff theme uses the background color to highlight diffs:

![Screen shot 2013-02-07 at 11 31 46 PM](https://f.cloud.github.com/assets/259316/138453/fd1c3490-71a8-11e2-8bda-98a598cfe2e1.png)

When I first tried out your plugin changed lines were showing up white and new lines were not showing up at all because that is the foreground color of my default diff rules.

After adding new scope rules for git_gutter it allows me to alter the foreground color just for your plugin context and now shows up like:

![Screen shot 2013-02-07 at 11 31 19 PM](https://f.cloud.github.com/assets/259316/138457/2f13466e-71a9-11e2-9e76-19300550f604.png)

Best of all this change is completely backwards compatible because of the way TextMate/Sublime handles scopes in their themes.
