### PR TITLE
Fixes problem with LookupError: unknown encoding: UTF-8withBOM

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -144,7 +144,7 @@ class GitGutterHandler:
                 self.buf_temp_file.name,
             ]
             results = self.run_command(args)
-            encoding = self.view.encoding()
+            encoding = self._get_view_encoding()
             try:
                 decoded_results = results.decode(encoding.replace(' ', ''))
             except UnicodeError:


### PR DESCRIPTION
Uses the encoding helper for cleaning up encodings in the diff.

Had problems with _LookupError: unknown encoding: UTF-8withBOM_ at line 149/150 in _git_gutter_handler.py_. This commit fixes it, and I don't see any immediate problems with using it at least.
