### PR TITLE
remove color escapes from diffs

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -141,7 +141,7 @@ class GitGutterHandler:
             self.update_git_file()
             self.update_buf_file()
             args = [
-                git_helper.git_command(self.view), 'diff', '-U0',
+                git_helper.git_command(self.view), 'diff', '-U0', '--no-color',
                 self.git_temp_file.name,
                 self.buf_temp_file.name,
             ]


### PR DESCRIPTION
If the color.ui=always config option is set for git, then GitGutter doesn't properly process the output of git diff. Adding the --no-color option to the diff command allows GitDiff to work
