### PR TITLE
Fix for #59

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -160,7 +160,7 @@ class GitGutterHandler:
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-            startupinfo=startupinfo)
+            startupinfo=startupinfo, stderr=subprocess.PIPE)
         return proc.stdout.read()
 
     def load_settings(self):


### PR DESCRIPTION
Handling the exception with `try`/`catch` is ok for sublime text, but it won't stop git from outputing to stderr.
I simply added `stderr=subprocess.PIPE` when running the command with Popen to redirect stderr so that it doesn't flood the terminal.
