### PR TITLE
Updated README with helpful note about theme settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ To implement, use the <kbd>Project</kbd> > <kbd>Edit Project</kbd> menu and add 
 
 The colors come from your *color scheme* **.tmTheme** file. If your color scheme file does not define the appropriate colors (or you want to edit them) add an entry that looks like this:
 
+NOTE: It is best to add this as the last entry in the main settings ```<array>``` to overide any other settings that might not allow the icons to appear.
+
 ```xml
 <dict>
   <key>name</key>


### PR DESCRIPTION
With some themes the settings will not get applied or behave oddly unless loaded last.  I added a note to the README to explain that it might be best to add the <dict> to the bottom of the array.  I had a theme that would overwrite only the addition and subtraction icons.  It turned out if I added the <dict> to the bottom it works fine.
