### PR TITLE
Live mode update delay

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -2,7 +2,7 @@
   // Custom path to git binary when not in PATH
   "git_binary": "",
   
-  // Live mode evaluates changes every time file is modified,
+  // Live mode evaluates changes every time file is modified
   // Set false to disable evaluation after each input
   "live_mode": true,
 
@@ -10,7 +10,7 @@
   // Set false to disable evaluation when changing views
   "focus_change_mode": true,
   
-  // When set to true GitGutter runs asynchronously in a seperate thread
+  // When set to true GitGutter runs asynchronously in a separate thread
   // This may cause a small delay between a modification and the icon change
   // but can increase performance greatly if needed.
   // Only available in Sublime Text 3.

--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -16,14 +16,22 @@
   // Only available in Sublime Text 3.
   "non_blocking": false,
 
-  // Wait this many milliseconds before evaluating input.
+  // Wait this many milliseconds between evaluating input.
+  // In effect this should have similar properties to non_blocking mode but
+  // without using threads, save more resources and work in Sublime Text 2.
   //
-  // For example, if set to 1000 and the user is typing constantly, evaluation
-  // will only take place once per second instead of after every key press.
-  // At lower values it should have similar properties to non_blocking mode but
-  // in addition work in Sublime Text 2.
+  // live_instant_interval dictates the minimum time between (near) instant
+  // evaluations on new input. When the file first receives input the evaluation
+  // is always instant, after which live_instant_interval time must pass before
+  // the next input is evaluated instantly again.
+  //
+  // live_continuous_delay dictates the minimum time between delayed evaluations.
+  // If input is continuous (faster than the live_instant_interval interval) then
+  // GitGutter will wait this long before evaluating.
   //
   // Has no effect with live_mode disabled or non_blocking enabled.
-  // Set to 0 to evaluate after each input with no delay.
-  "live_delay": 200
+  // Set live_delay to false to evaluate after each input with no delay.
+  "live_delay": false,
+  "live_instant_interval": 200,
+  "live_continuous_delay": 400
 }

--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -13,5 +13,17 @@
   // When set to true GitGutter runs asynchronously in a seperate thread
   // This may cause a small delay between a modification and the icon change
   // but can increase performance greatly if needed.
-  "non_blocking": false
+  // Only available in Sublime Text 3.
+  "non_blocking": false,
+
+  // Wait this many milliseconds before evaluating input.
+  //
+  // For example, if set to 1000 and the user is typing constantly, evaluation
+  // will only take place once per second instead of after every key press.
+  // At lower values it should have similar properties to non_blocking mode but
+  // in addition work in Sublime Text 2.
+  //
+  // Has no effect with live_mode disabled or non_blocking enabled.
+  // Set to 0 to evaluate after each input with no delay.
+  "live_delay": 200
 }

--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -8,14 +8,23 @@ except ImportError:
 class GitGutterEvents(sublime_plugin.EventListener):
     def __init__(self):
         self.load_settings()
+        self.delayed_update_scheduled = False
 
     # Synchronous
+
+    def delayed_update(self, view):
+        ViewCollection.add(view)
+        self.delayed_update_scheduled = False
 
     def on_modified(self, view):
         if not self.live_mode:
             return None
         if not self.non_blocking:
-            ViewCollection.add(view)
+            if not self.live_delay:
+                ViewCollection.add(view)
+            elif not self.delayed_update_scheduled:
+                self.delayed_update_scheduled = True
+                sublime.set_timeout(lambda: self.delayed_update(view), self.live_delay)
 
     def on_clone(self, view):
         if not self.non_blocking:
@@ -66,6 +75,10 @@ class GitGutterEvents(sublime_plugin.EventListener):
         self.live_mode = self.settings.get('live_mode')
         if self.live_mode is None: 
             self.live_mode = True
+
+        self.live_delay = self.settings.get('live_delay')
+        if self.live_delay is None:
+            self.live_delay = 0
 
         self.focus_change_mode = self.settings.get('focus_change_mode')
         if self.focus_change_mode is None:

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -42,7 +42,10 @@ class GitGutterHandler:
 
     def reset(self):
         if self.on_disk() and self.git_path:
-            self.view.window().run_command('git_gutter')
+            try:
+                self.view.window().run_command('git_gutter')
+            except AttributeError:
+                pass
 
     def get_git_path(self):
         return self.git_path


### PR DESCRIPTION
From the config comment:

  // Wait this many milliseconds between evaluating input.
  // In effect this should have similar properties to non_blocking mode but
  // without using threads, save more resources and work in Sublime Text 2.
  //
  // live_instant_interval dictates the minimum time between (near) instant
  // evaluations on new input. When the file first receives input the evaluation
  // is always instant, after which live_instant_interval time must pass before
  // the next input is evaluated instantly again.
  //
  // live_continuous_delay dictates the minimum time between delayed evaluations.
  // If input is continuous (faster than the live_instant_interval interval) then
  // GitGutter will wait this long before evaluating.
  //
  // Has no effect with live_mode disabled or non_blocking enabled.
  // Set live_delay to false to evaluate after each input with no delay.
  "live_delay": true,
  "live_instant_interval": 200,
  "live_continuous_delay": 400
