### PR TITLE
readme: Use anonymous git url for Ubuntu and Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Or you can clone this repo into your *Sublime Text 2/Packages*
 *OSX*
 ```shell
 cd ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/
-git clone git@github.com:jisaacks/GitGutter.git
+git clone git://github.com/jisaacks/GitGutter.git
 ```
 
 *Ubuntu*
 ```shell
 cd ~/.config/sublime-text-2/Packages
-git clone git@github.com:jisaacks/GitGutter.git
+git clone git://github.com/jisaacks/GitGutter.git
 ```
 
 *Windows*


### PR DESCRIPTION
The Windows section uses this already.

The authenticated url will fail if the user doesn't have access
set up for the Git.
