### PR TITLE
Added ignore_whitespace option

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -13,5 +13,11 @@
   // When set to true GitGutter runs asynchronously in a seperate thread
   // This may cause a small delay between a modification and the icon change
   // but can increase performance greatly if needed.
-  "non_blocking": false
+  "non_blocking": false,
+
+  // Determines whether GitGutter ignores whitespace in modified files.
+  // Set "none" to ensure whitespace is considered in the diff
+  // Set "all" to ignore all white space
+  // Set "eol" to only ignore whitespace at the end of lines
+  "ignore_whitespace": "none"
 }

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -141,6 +141,7 @@ class GitGutterHandler:
             self.update_buf_file()
             args = [
                 self.git_binary_path, 'diff', '-U0', '--no-color',
+                if self.ignore_whitespace: self.ignore_whitespace,
                 self.git_temp_file.name,
                 self.buf_temp_file.name,
             ]
@@ -169,3 +170,11 @@ class GitGutterHandler:
         git_binary = self.settings.get('git_binary')
         if git_binary:
             self.git_binary_path = git_binary
+
+        self.ignore_whitespace = self.settings.get('ignore_whitespace')
+        if self.ignore_whitespace == 'all':
+            self.ignore_whitespace = '-w'
+        elif self.ignore_whitespace == 'eol':
+            self.ignore_whitespace = '--ignore-space-at-eol'
+        else:
+            self.ignore_whitespace = False


### PR DESCRIPTION
Allows the user to chose whether or not whitespace is ignored by GitGutter. Three options:
- "none" (default) retains the current default behaviour of including whitespace
- "all" ignores all whitespace, adds -w arg
- "eol" only ignores whitespace at the end of lines, adds --ignore-space-at-eol arg
