### PR TITLE
fixes AttributeError: 'NoneType'... when views are activated via the `Goto Anything` palette

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -41,7 +41,7 @@ class GitGutterHandler:
         return self.view.file_name() is not None
 
     def reset(self):
-        if self.on_disk() and self.git_path:
+        if self.on_disk() and self.git_path and self.view.window():
             self.view.window().run_command('git_gutter')
 
     def get_git_path(self):


### PR DESCRIPTION
don't run git_gutter in a view if it has no window: fixes AttributeError: 'NoneType'... when views are activated via the `Goto Anything` palette
