### PR TITLE
bugfix: GitGutter icons can now display in submodules

### DIFF
--- a/git_helper.py
+++ b/git_helper.py
@@ -38,8 +38,10 @@ def git_dir(directory):
         with open(pre_git_dir) as submodule_git_file:
             submodule_path = submodule_git_file.read()
             submodule_path = os.path.join('..', submodule_path.split()[1])
-            submodule_git_dir = os.path.abspath(os.path.join(pre_git_dir,
-                                                             submodule_git_dir)
+
+            submodule_git_dir = os.path.abspath(
+                os.path.join(pre_git_dir, submodule_path))
+
         return submodule_git_dir
     else:
         return pre_git_dir


### PR DESCRIPTION
related with https://github.com/jisaacks/GitGutter/issues/115

This pull request has several issues, but at least is works:)

I think the submodule's `--git-dir` argument is wrong in the previous implementation, that caused the abnormal behavior in submodule files.

I'm not sure if my code is working good for nested submodules, but at least it works in one-level submoduels:)

btw, my pep8 checker is telling me:
`git_helper.py|46| 1: E901 TokenError: EOF in multi-line statement`

I think maybe this is because I'm using windows...
