### PR TITLE
Added 'Key Bindings' items to Sublime main menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -3,17 +3,17 @@
         "id": "goto",
         "children":
         [
-            { 
-                "caption": "Previous change", 
+            {
+                "caption": "Previous change",
                 "command": "git_gutter_prev_change"
             },
-            { 
-                "caption": "Next change",     
+            {
+                "caption": "Next change",
                 "command": "git_gutter_next_change"
             }
         ]
-    }
-    ,{
+    },
+    {
         "caption": "Preferences",
         "mnemonic": "n",
         "id": "preferences",
@@ -38,6 +38,55 @@
                                 "command": "open_file",
                                 "args": {"file": "${packages}/User/GitGutter.sublime-settings"},
                                 "caption": "Settings – User"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/GitGutter/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/GitGutter/Default (Linux).sublime-keymap",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/GitGutter/Default (Windows).sublime-keymap",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Key Bindings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Key Bindings – User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Key Bindings – User"
                             }
                         ]
                     }


### PR DESCRIPTION
This allows to easily change default key bindings
for 'goto next/prev change' command.
