### PR TITLE
Fixed a minor code block syntax problem in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can toggle the setting `show_markers_on_untracked_file` to show special icon
 If git is not in your PATH, you may need to set the `git_binary` setting to the location of the git binary, e.g. in a portable environment;
 ```json
 {
-"git_binary": "E:\Portable\git\bin\git.exe"
+  "git_binary": "E:\\Portable\\git\\bin\\git.exe"
 }
 ```
 


### PR DESCRIPTION
By using curly quotation marks for the string in the code snippet some Markdown processors weren't able to close the string properly. GitHub was smart enough to handle this correctly but it was causing problems on the [Package Control](https://sublime.wbond.net/packages/GitGutter) site.

![gitgutter_-_packages_-_package_control](https://f.cloud.github.com/assets/1746405/1776282/ac50e386-6814-11e3-8761-0ecf8a524510.png)

I replaced the curly quotation marks for the agnostic flavor. I also switched the language from 'js' to 'json'
