### PR TITLE
Keep Special marker on untracked files at false in default.

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -22,7 +22,7 @@
   "ignore_whitespace": "none",
 
   // Add a special marker on untracked files
-  "show_markers_on_untracked_file": true,
+  "show_markers_on_untracked_file": false,
 
   // Add --patience switch to git diff command. See
   // http://bramcohen.livejournal.com/73318.html for 


### PR DESCRIPTION
Keep this default setting to false, this makes the editor better for performance.
Try to leave shortcut ctrl + z press after many changes to one file, the editor will slow down. 

I think this is more logical to not have marker on unmodified files. I was surprised to have markers in my files folder "vendor" in my project.
