### PR TITLE
Reversed keybindings for previous/next change.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
 [
-    { "keys": ["ctrl+shift+alt+j"], "command": "git_gutter_next_change" },
-    { "keys": ["ctrl+shift+alt+k"], "command": "git_gutter_prev_change" }
+    { "keys": ["ctrl+shift+alt+k"], "command": "git_gutter_next_change" },
+    { "keys": ["ctrl+shift+alt+j"], "command": "git_gutter_prev_change" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-    { "keys": ["super+shift+option+j"], "command": "git_gutter_next_change" },
-    { "keys": ["super+shift+option+k"], "command": "git_gutter_prev_change" }
+    { "keys": ["super+shift+option+k"], "command": "git_gutter_next_change" },
+    { "keys": ["super+shift+option+j"], "command": "git_gutter_prev_change" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [
-    { "keys": ["ctrl+shift+alt+j"], "command": "git_gutter_next_change" },
-    { "keys": ["ctrl+shift+alt+k"], "command": "git_gutter_prev_change" }
+    { "keys": ["ctrl+shift+alt+k"], "command": "git_gutter_next_change" },
+    { "keys": ["ctrl+shift+alt+j"], "command": "git_gutter_prev_change" }
 ]


### PR DESCRIPTION
The current keybindings for previous/next change are confusing, as
every other instance of previous/next has previous on the left and
next on the right.

Some examples: The arrow keys and a+s in first person shooters.
