### PR TITLE
Split changes and insertions on consecutive lines

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -127,6 +127,9 @@ class GitGutterHandler:
                 inserted += range(start, start + new_size)
             elif not new_size:
                 deleted += [start + 1]
+            elif old_size:
+                modified += range(start, start + old_size)
+                inserted += range(start, start + new_size)
             else:
                 modified += range(start, start + new_size)
         if len(inserted) == self.total_lines() and not self.show_untracked:


### PR DESCRIPTION
Currently if a change is immediately followed by an insertion on the next line, both change and insertion are highlighted as change. I tried to fix it myself, but unfortunately this breaks highlighting changes as they are displayed as insertion instead of changes. Perhaps you can take a look?
