### PR TITLE
Use get_handler method in ViewCollection to avoid key error

### DIFF
--- a/view_collection.py
+++ b/view_collection.py
@@ -47,23 +47,19 @@ class ViewCollection:
 
     @staticmethod
     def diff(view):
-        key = ViewCollection.get_key(view)
-        return ViewCollection.views[key].diff()
+        return ViewCollection.get_handler(view).diff()
 
     @staticmethod
     def untracked(view):
-        key = ViewCollection.get_key(view)
-        return ViewCollection.views[key].untracked()
+        return ViewCollection.get_handler(view).untracked()
 
     @staticmethod
     def ignored(view):
-        key = ViewCollection.get_key(view)
-        return ViewCollection.views[key].ignored()
+        return ViewCollection.get_handler(view).ignored()
 
     @staticmethod
     def total_lines(view):
-        key = ViewCollection.get_key(view)
-        return ViewCollection.views[key].total_lines()
+        return ViewCollection.get_handler(view).total_lines()
 
     @staticmethod
     def git_time(view):


### PR DESCRIPTION
When calling the untracked method of ViewCollection, it happens quite often that the views dictionary doesn't contain the key. Thus, leading to a key error.
I don't know whether there was a specific reason to not use the existing get_handler function, but I think that this solves the issue.
