### PR TITLE
Work with ConvertToUTF8 plugin.

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -36,7 +36,10 @@ class GitGutterHandler:
         encoding = encoding.replace('Windows', 'cp')
         encoding = encoding.replace('-', '_')
         encoding = encoding.replace(' ', '')
-        return encoding
+
+        # work around with ConvertToUTF8 plugin
+        origin_encoding = self.view.settings().get('origin_encoding')
+        return origin_encoding or encoding
 
     def on_disk(self):
         # if the view is saved to disk


### PR DESCRIPTION
ConvertToUTF8 store the file's encoding in the setting "origin_encoding". For details, please see: https://github.com/seanliang/ConvertToUTF8/blob/master/ConvertToUTF8.py

Without this patch, GitGutter will fail to detect right encoding for a GBK content file opened with ConvertToUTF8. 

ConvertToUTF8 is a very popular plugin (Top 25, see https://sublime.wbond.net/packages/ConvertToUTF8), especially among Chinese. Of course it's up for you to decide whether this patch is worthy.
