### PR TITLE
Fix for ST3 not working with Cygwin git

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -146,7 +146,7 @@ class GitGutterHandler:
             self.update_git_file()
             self.update_buf_file()
             args = [
-                self.git_binary_path, 'diff', '-U0', '--no-color',
+                self.git_binary_path, 'diff', '-U0', '--no-color', '--no-index',
                 self.ignore_whitespace,
                 self.patience_switch,
                 self.git_temp_file.name,


### PR DESCRIPTION
GitGutter did not work on my Win7/Cygwin, ST3 setup.  Explicitly specifying `no-index` to the diff subprocess (instead of relying on implicit detection) fixes the issue, and poses no risk to other systems.

My symptoms are the same as #191:

* Args to Popen: ['git', 'diff', '-U0', '--no-color', '--patience', 'c:\users\...\temp\tmpxxxxxx', 'c:\users\...\temp\tmpyyyyyy']
* Results of above subproc to stdout are an empty binary string: b''
* Running the command on the CLI (cmd, or bash) results in a good diff

I agree with @0m4r in #146 that the problem is in git, which fails to correctly identify when Windows paths are outside the repository (when using Cygwin), even though it does handles those Windows paths when `no-index` is used explicitly. Perhaps the issue is inside [path_inside_repo(..)](https://github.com/git/git/blob/670a3c1d5a27bfb1cc6b526559c6f5874f00042f/builtin/diff.c#L315).

This may also affect #152, given the mention of paths at the end of that conversation.
