### PR TITLE
Fix capitalization of menu items

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -45,11 +45,11 @@
         "children":
         [
             {
-                "caption": "Previous change",
+                "caption": "Previous Change",
                 "command": "git_gutter_prev_change"
             },
             {
-                "caption": "Next change",
+                "caption": "Next Change",
                 "command": "git_gutter_next_change"
             }
         ]


### PR DESCRIPTION
This PR changes the capitalization of the `Previous Change` and `Next Change` menu items to look more similar to the surrounding menu items. For reference, here is a screenshot of the current Goto menu:

<img src="https://cloud.githubusercontent.com/assets/2434728/7110722/0432481c-e16b-11e4-925e-b73749cecc75.png" width="283px">