### PR TITLE
Allowing git_binary to be customized on a per-platform basis.

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -1,5 +1,16 @@
 {
-  // Custom path to git binary when not in PATH
+  // Custom path to git binary when not in PATH.  An empty string will search
+  // PATH for "git".  The setting may be a direct string to a git binary, e.g.:
+  //
+  //   "git_binary": "/usr/bin/git",
+  //
+  // Or it may be a dictionary keyed off what sublime.platform() returns,
+  // so it may be customized on a per-platform basis.  e.g.:
+  //
+  //   "git_binary": {
+  //       "default": "",
+  //       "windows": "C:/Program Files/Git/cmd/git.exe"
+  //   },
   "git_binary": "",
 
   // The commit, branch, tag, or remote to compare against

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Or it may be a dictionary keyed off what sublime.platform() returns, so it may b
 }
 ```
 
-Or in a POSIX environment you can run `which git` to find the path to git if it is in your path.
+It is valid to use environment variables in the setting value, and they will be expanded appropriately.
+
+In a POSIX environment you can run `which git` to find the path to git if it is in your path.  On Windows, you can use `where git` to do the equivalent.
 
 #### Protected Regions
 Is GitGutter blocking SublimeLinter or other icons? You can prevent this by adding which regions you would like GitGutter to not override:

--- a/README.md
+++ b/README.md
@@ -78,10 +78,22 @@ GitGutter shows icons for new files and ignored files. These icons will be on ev
 GitGutter will show diffs in the minimap on Sublime Text 3. This can be disabled by setting `show_in_minimap` to `false`.
 
 #### Git path
-If `git` is not found by GitGutter you may need to set the `git_binary` setting to the location of the git binary, e.g. in a portable environment;
+If `git` is not found by GitGutter you may need to set the `git_binary` setting to the location of the git binary.  The value may be either a direct string to a git binary:
 ```javascript
-"git_binary": "E:\\Portable\\git\\bin\\git.exe"
+{
+  "git_binary": "E:\\Portable\\git\\bin\\git.exe"
+}
 ```
+
+Or it may be a dictionary keyed off what sublime.platform() returns, so it may be customized on a per-platform basis:
+```javascript
+"git_binary": {
+  "default": "",
+  "linux": "/usr/bin/git",
+  "windows": "C:/Program Files/Git/cmd/git.exe"
+}
+```
+
 Or in a POSIX environment you can run `which git` to find the path to git if it is in your path.
 
 #### Protected Regions

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -269,11 +269,24 @@ class GitGutterHandler:
             'Preferences.sublime-settings')
 
         # Git Binary Setting
-        self.git_binary_path = 'git'
-        git_binary = self.user_settings.get(
-            'git_binary') or self.settings.get('git_binary')
-        if git_binary:
-            self.git_binary_path = git_binary
+        git_binary_setting = self.user_settings.get("git_binary") or \
+                             self.settings.get("git_binary")
+        if isinstance(git_binary_setting, dict):
+            self.git_binary_path = git_binary_setting.get(sublime.platform())
+            if not self.git_binary_path:
+                self.git_binary_path = git_binary_setting.get('default')
+        else:
+            self.git_binary_path = git_binary_setting
+
+        if not self.git_binary_path:
+            self.git_binary_path = shutil.which("git")
+
+        if not self.git_binary_path:
+            msg = ("Your Git binary cannot be found.  If it is installed, add it "
+                   "to your PATH environment variable, or add a `git_binary` setting "
+                   "in the `User/GitGutter.sublime-settings` file.")
+            sublime.error_message(msg)
+            raise ValueError("Git binary not found.")
 
         # Ignore White Space Setting
         self.ignore_whitespace = self.settings.get('ignore_whitespace')

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -278,7 +278,9 @@ class GitGutterHandler:
         else:
             self.git_binary_path = git_binary_setting
 
-        if not self.git_binary_path:
+        if self.git_binary_path:
+            self.git_binary_path = os.path.expandvars(self.git_binary_path)
+        else:
             self.git_binary_path = shutil.which("git")
 
         if not self.git_binary_path:


### PR DESCRIPTION
On Windows, git isn't always in PATH, requiring you to set git_binary for GitGutter to work correctly.  For users that sync settings across platforms, this allows git_binary to be (optionally) customized on a per-platform basis.