### PR TITLE
Add minimap support (ST3 only)

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -48,6 +48,9 @@
   // Set "all" to also show on what branch you are
   "show_status": "default",
 
+  // Show GitGutter information in the minimap
+  "show_in_minimap": true,
+
   // Determines whether the git_gutter_next_change and git_gutter_prev_change
   // commands wrap around on reaching the beginning/ending of the file.
   "next_prev_change_wrap": true

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ By default, GitGutter detects changes every time the file is modified. If you ex
 #### Untracked Files
 GitGutter shows icons for new files and ignored files. These icons will be on every line. You can toggle the setting `show_markers_on_untracked_file` to turn this feature off. Defaults to true (shows icons). You may need to add scopes to your color scheme (`markup.ignored.git_gutter` and `markup.untracked.git_gutter`) to color the icons.
 
+#### Minimap
+GitGutter will show diffs in the minimap on Sublime Text 3. This can be disabled by setting `show_in_minimap` to `false`.
+
 #### Git path
 If git is not in your PATH, you may need to set the `git_binary` setting to the location of the git binary, e.g. in a portable environment;
 ```json

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -27,6 +27,7 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
             return
 
         self.clear_all()
+        self.show_in_minimap = settings.get('show_in_minimap', True)
         show_untracked = settings.get('show_markers_on_untracked_file', False)
 
         if ViewCollection.untracked(self.view):
@@ -81,7 +82,7 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
         regions = []
         for line in lines:
             position = self.view.text_point(line - 1, 0)
-            region = sublime.Region(position, position)
+            region = sublime.Region(position, position+1)
             regions.append(region)
         return regions
 
@@ -126,7 +127,8 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
             event_scope = 'deleted'
         scope = 'markup.%s.git_gutter' % event_scope
         icon = self.icon_path(event)
-        self.view.add_regions('git_gutter_%s' % event, regions, scope, icon)
+        flags = (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE if (ST3 and self.show_in_minimap) else sublime.HIDDEN)
+        self.view.add_regions('git_gutter_%s' % event, regions, scope, icon, flags)
 
     def bind_files(self, event):
         lines = []

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -142,7 +142,10 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
             event_scope = 'deleted'
         scope = 'markup.%s.git_gutter' % event_scope
         icon = self.icon_path(event)
-        flags = (sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE if (ST3 and self.show_in_minimap) else sublime.HIDDEN)
+        if ST3 and self.show_in_minimap:
+            flags = sublime.DRAW_NO_FILL | sublime.DRAW_NO_OUTLINE
+        else:
+            flags = sublime.HIDDEN
         self.view.add_regions('git_gutter_%s' % event, regions, scope, icon, flags)
 
     def bind_files(self, event):

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -292,6 +292,9 @@ class GitGutterHandler:
         self.show_untracked = self.settings.get(
             'show_markers_on_untracked_file')
 
+        # Show in minimap
+        self.show_in_minimap = self.user_settings.get('show_in_minimap') or self.settings.get('show_in_minimap')
+
         # Show information in status bar
         self.show_status = self.user_settings.get('show_status') or self.settings.get('show_status')
         if self.show_status != 'all' and self.show_status != 'none':


### PR DESCRIPTION
I've added support for showing gutter marks in the minimap (#55), but it only works on ST3.
Unsure if you want to merge or not because of this, however it does safely disable in ST2.

Here's a screenshot showing ST3 and ST2 respectively.

<img width="564" alt="screen shot 2015-08-05 at 21 07 49" src="https://cloud.githubusercontent.com/assets/1525809/9096613/1865b076-3bb6-11e5-85e2-61e01530ab3e.png">

Here's a non-retina screenshot showing a much bigger file. Makes it a lot easier to spot diffs.

![screen shot 2015-08-06 at 10 40 37](https://cloud.githubusercontent.com/assets/1525809/9108685/be5ec9ce-3c27-11e5-90db-83926cd123a6.png)

