### PR TITLE
Support environment variables in git_binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ If git is not in your PATH, you may need to set the `git_binary` setting to the 
 }
 ```
 
+You can also use environmental variables in your git_binary path (Windows example):
+```json
+{
+  "git_binary": "%EnvVar%\\git\\bin\\git.exe"
+}
+```
+
 
 #### Per-project Settings
 Sublime Text supports project-specific settings, allowing `live_mode` to be set differently for different repositories.

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -254,11 +254,15 @@ class GitGutterHandler:
 
     def run_command(self, args):
         startupinfo = None
+        # Per http://bugs.python.org/issue8557 shell=True is required to
+        # get $PATH on Windows. Yay portable code.
+        shell = os.name == 'nt'
         if os.name == 'nt':
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                startupinfo=startupinfo, stderr=subprocess.PIPE)
+                                startupinfo=startupinfo, stderr=subprocess.PIPE,
+                                shell=shell, env=os.environ)
         return proc.stdout.read()
 
     def load_settings(self):

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -254,15 +254,11 @@ class GitGutterHandler:
 
     def run_command(self, args):
         startupinfo = None
-        # Per http://bugs.python.org/issue8557 shell=True is required to
-        # get $PATH on Windows. Yay portable code.
-        shell = os.name == 'nt'
         if os.name == 'nt':
             startupinfo = subprocess.STARTUPINFO()
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                startupinfo=startupinfo, stderr=subprocess.PIPE,
-                                shell=shell, env=os.environ)
+                                startupinfo=startupinfo, stderr=subprocess.PIPE)
         return proc.stdout.read()
 
     def load_settings(self):
@@ -275,7 +271,7 @@ class GitGutterHandler:
         git_binary = self.user_settings.get(
             'git_binary') or self.settings.get('git_binary')
         if git_binary:
-            self.git_binary_path = git_binary
+            self.git_binary_path = os.path.expandvars(git_binary)
 
         # Ignore White Space Setting
         self.ignore_whitespace = self.settings.get('ignore_whitespace')


### PR DESCRIPTION
I have an environmental variable that I use to reference my portable apps folder that changes from computer to computer. After taking a look at the code for the [Sublime Text Git plugin](https://github.com/kemayo/sublime-text-git) I noticed it wasn't too bad to support loading environmental variables.

Example config on Windows:
```json
{ "git_command": "%Apps%\\Cmder\\vendor\\msysgit\\bin\\git.exe" }
```