### PR TITLE
Fix error invoking git which happens on all of my Windows systems.

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -362,12 +362,14 @@ class GitGutterHandler(object):
     def run_command(args):
         def read_output(resolve):
             startupinfo = None
+            stdin = None
             if os.name == 'nt':
                 startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                stdin = subprocess.PIPE
             proc = subprocess.Popen(
                 args, stdout=subprocess.PIPE, startupinfo=startupinfo,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE, stdin=stdin)
             stdout_output = proc.stdout.read()
             resolve(stdout_output)
 


### PR DESCRIPTION
Trying to invoke git always throws the following error to my
console:

OSError: [WinError 6] The handle is invalid

Populating stdin/stderr with subprocess.PIPE fixes the problem.  I
think this is the following Python bug:

https://bugs.python.org/issue3905

Note that some others have tripped across this issue, too.  See the
second comment by @flux242 in issue #146.
