### PR TITLE
Add an identifiable prefix to temp files

### DIFF
--- a/view_collection.py
+++ b/view_collection.py
@@ -83,7 +83,8 @@ class ViewCollection:
     def git_tmp_file(view):
         key = ViewCollection.get_key(view)
         if not key in ViewCollection.git_files:
-            ViewCollection.git_files[key] = tempfile.NamedTemporaryFile()
+            ViewCollection.git_files[key] = \
+                tempfile.NamedTemporaryFile(prefix='git_gutter_')
             ViewCollection.git_files[key].close()
         return ViewCollection.git_files[key]
 
@@ -91,7 +92,8 @@ class ViewCollection:
     def buf_tmp_file(view):
         key = ViewCollection.get_key(view)
         if not key in ViewCollection.buf_files:
-            ViewCollection.buf_files[key] = tempfile.NamedTemporaryFile()
+            ViewCollection.buf_files[key] = \
+                tempfile.NamedTemporaryFile(prefix='git_gutter_')
             ViewCollection.buf_files[key].close()
         return ViewCollection.buf_files[key]
 


### PR DESCRIPTION
After a long sublime session I find my /tmp directory littered with temp files created by Git Gutter. It's worse on Windows where the %TEMP% directory is persistent. It would be helpful to be able to identify files left behind by GitGutter so they can be manually cleaned up.

Ideally Git Gutter would remove these files when they are not needed. I'll work on that next.