### PR TITLE
FIX for ISSUE #284: Delete temporary files if a view is closed.

### DIFF
--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -40,6 +40,9 @@ class GitGutterEvents(sublime_plugin.EventListener):
 
     # Synchronous
 
+    def on_close(self, view):
+        ViewCollection.remove(view)
+
     def on_modified(self, view):
         if self.settings_loaded() and self.live_mode:
             self.debounce(view, 'modified', ViewCollection.add)

--- a/view_collection.py
+++ b/view_collection.py
@@ -1,3 +1,4 @@
+import os
 import sublime
 import tempfile
 import time
@@ -20,6 +21,17 @@ class ViewCollection:
         handler = ViewCollection.views[key] = GitGutterHandler(view)
         handler.reset()
         return handler
+
+    @staticmethod
+    def remove(view):
+        key = ViewCollection.get_key(view)
+        if key in ViewCollection.git_files:
+            os.unlink(ViewCollection.git_files[key].name)
+            del (ViewCollection.git_files[key])
+
+        if key in ViewCollection.buf_files:
+            os.unlink(ViewCollection.buf_files[key].name)
+            del (ViewCollection.buf_files[key])
 
     @staticmethod
     def git_path(view):
@@ -84,7 +96,7 @@ class ViewCollection:
         key = ViewCollection.get_key(view)
         if not key in ViewCollection.git_files:
             ViewCollection.git_files[key] = \
-                tempfile.NamedTemporaryFile(prefix='git_gutter_')
+                tempfile.NamedTemporaryFile(prefix='git_gutter_', delete=False)
             ViewCollection.git_files[key].close()
         return ViewCollection.git_files[key]
 
@@ -93,7 +105,7 @@ class ViewCollection:
         key = ViewCollection.get_key(view)
         if not key in ViewCollection.buf_files:
             ViewCollection.buf_files[key] = \
-                tempfile.NamedTemporaryFile(prefix='git_gutter_')
+                tempfile.NamedTemporaryFile(prefix='git_gutter_', delete=False)
             ViewCollection.buf_files[key].close()
         return ViewCollection.buf_files[key]
 


### PR DESCRIPTION
I managed to find a way to delete temporary files and remove them from the ViewCollection object triggered by the on_close() event. This is a real synchronous event callback, but normally deleting two files, should not take much time.
