### PR TITLE
Add bookmarks to protected regions

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -71,6 +71,7 @@
   // regions, (e.g. Bookmarks, Linter/BracketHighlighter icons.)
   "protected_regions": [
     "sublimelinter-warning-gutter-marks",
-    "sublimelinter-error-gutter-marks"  
+    "sublimelinter-error-gutter-marks",
+    "bookmarks"
   ]
 }


### PR DESCRIPTION
Prevent GitGutter from overwriting bookmark icons.