### PR TITLE
Add GitGutterSettings class that encapsulates settings (#230 related)

### DIFF
--- a/git_gutter.py
+++ b/git_gutter.py
@@ -3,22 +3,23 @@ import sublime
 import sublime_plugin
 
 try:
+    from .git_gutter_settings import GitGutterSettings
     from .view_collection import ViewCollection
 except (ImportError, ValueError):
+    from git_gutter_settings import GitGutterSettings
     from view_collection import ViewCollection
 
 ST3 = int(sublime.version()) >= 3000
-
-
-def plugin_loaded():
-    global settings
-    settings = sublime.load_settings('GitGutter.sublime-settings')
 
 
 class GitGutterCommand(sublime_plugin.WindowCommand):
     region_names = ['deleted_top', 'deleted_bottom',
                     'deleted_dual', 'inserted', 'changed',
                     'untracked', 'ignored']
+
+    def __init__(self, *args, **kwargs):
+        sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
+        self.settings = GitGutterSettings()
 
     def run(self, force_refresh=False):
         self.view = self.window.active_view()
@@ -28,8 +29,9 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
             return
 
         self.clear_all()
-        self.show_in_minimap = settings.get('show_in_minimap', True)
-        show_untracked = settings.get('show_markers_on_untracked_file', False)
+        self.show_in_minimap = self.settings.get('show_in_minimap', True)
+        show_untracked = self.settings.get('show_markers_on_untracked_file',
+                                           False)
 
         if ViewCollection.untracked(self.view):
             if show_untracked:
@@ -81,7 +83,7 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
 
     def is_region_protected(self, region):
         # Load protected Regions from Settings
-        protected_regions = settings.get('protected_regions',[])
+        protected_regions = self.settings.get('protected_regions',[])
         # List of Lists of Regions
         sets = [self.view.get_regions(r) for r in protected_regions]
         # List of Regions
@@ -158,7 +160,3 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
             lines += [i + 1]
             i = i + 1
         self.bind_icons(event, lines)
-
-
-if not ST3:
-    plugin_loaded()

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -3,10 +3,10 @@ import sublime
 import sublime_plugin
 
 try:
-    from .git_gutter_settings import GitGutterSettings
+    from .git_gutter_settings import settings
     from .view_collection import ViewCollection
 except (ImportError, ValueError):
-    from git_gutter_settings import GitGutterSettings
+    from git_gutter_settings import settings
     from view_collection import ViewCollection
 
 ST3 = int(sublime.version()) >= 3000
@@ -17,10 +17,6 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
                     'deleted_dual', 'inserted', 'changed',
                     'untracked', 'ignored']
 
-    def __init__(self, *args, **kwargs):
-        sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
-        self.settings = GitGutterSettings()
-
     def run(self, force_refresh=False):
         self.view = self.window.active_view()
         if not self.view:
@@ -29,9 +25,8 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
             return
 
         self.clear_all()
-        self.show_in_minimap = self.settings.get('show_in_minimap', True)
-        show_untracked = self.settings.get('show_markers_on_untracked_file',
-                                           False)
+        self.show_in_minimap = settings.get('show_in_minimap', True)
+        show_untracked = settings.get('show_markers_on_untracked_file', False)
 
         if ViewCollection.untracked(self.view):
             if show_untracked:
@@ -83,7 +78,7 @@ class GitGutterCommand(sublime_plugin.WindowCommand):
 
     def is_region_protected(self, region):
         # Load protected Regions from Settings
-        protected_regions = self.settings.get('protected_regions',[])
+        protected_regions = settings.get('protected_regions', [])
         # List of Lists of Regions
         sets = [self.view.get_regions(r) for r in protected_regions]
         # List of Regions

--- a/git_gutter_change.py
+++ b/git_gutter_change.py
@@ -1,19 +1,18 @@
-import sublime
 import sublime_plugin
+
 try:
+    from .git_gutter_settings import GitGutterSettings
     from .view_collection import ViewCollection
 except (ImportError, ValueError):
+    from .git_gutter_settings import GitGutterSettings
     from view_collection import ViewCollection
-
-ST3 = int(sublime.version()) >= 3000
-
-
-def plugin_loaded():
-    global settings
-    settings = sublime.load_settings('GitGutter.sublime-settings')
 
 
 class GitGutterBaseChangeCommand(sublime_plugin.WindowCommand):
+    def __init__(self, *args, **kwargs):
+        sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
+        self.settings = GitGutterSettings()
+        self.settings.load_settings()
 
     def lines_to_blocks(self, lines):
         blocks = []
@@ -44,7 +43,7 @@ class GitGutterBaseChangeCommand(sublime_plugin.WindowCommand):
 class GitGutterNextChangeCommand(GitGutterBaseChangeCommand):
 
     def jump(self, all_changes, current_row):
-        if settings.get('next_prev_change_wrap', True):
+        if self.settings.get('next_prev_change_wrap', True):
             default = all_changes[0]
         else:
             default = all_changes[-1]
@@ -56,14 +55,10 @@ class GitGutterNextChangeCommand(GitGutterBaseChangeCommand):
 class GitGutterPrevChangeCommand(GitGutterBaseChangeCommand):
 
     def jump(self, all_changes, current_row):
-        if settings.get('next_prev_change_wrap', True):
+        if self.settings.get('next_prev_change_wrap', True):
             default = all_changes[-1]
         else:
             default = all_changes[0]
 
         return next((change for change in reversed(all_changes)
                     if change < current_row), default)
-
-
-if not ST3:
-    plugin_loaded()

--- a/git_gutter_change.py
+++ b/git_gutter_change.py
@@ -1,19 +1,14 @@
 import sublime_plugin
 
 try:
-    from .git_gutter_settings import GitGutterSettings
+    from .git_gutter_settings import settings
     from .view_collection import ViewCollection
 except (ImportError, ValueError):
-    from .git_gutter_settings import GitGutterSettings
+    from git_gutter_settings import settings
     from view_collection import ViewCollection
 
 
 class GitGutterBaseChangeCommand(sublime_plugin.WindowCommand):
-    def __init__(self, *args, **kwargs):
-        sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
-        self.settings = GitGutterSettings()
-        self.settings.load_settings()
-
     def lines_to_blocks(self, lines):
         blocks = []
         last_line = -2
@@ -41,9 +36,8 @@ class GitGutterBaseChangeCommand(sublime_plugin.WindowCommand):
 
 
 class GitGutterNextChangeCommand(GitGutterBaseChangeCommand):
-
     def jump(self, all_changes, current_row):
-        if self.settings.get('next_prev_change_wrap', True):
+        if settings.get('next_prev_change_wrap', True):
             default = all_changes[0]
         else:
             default = all_changes[-1]
@@ -53,9 +47,8 @@ class GitGutterNextChangeCommand(GitGutterBaseChangeCommand):
 
 
 class GitGutterPrevChangeCommand(GitGutterBaseChangeCommand):
-
     def jump(self, all_changes, current_row):
-        if self.settings.get('next_prev_change_wrap', True):
+        if settings.get('next_prev_change_wrap', True):
             default = all_changes[-1]
         else:
             default = all_changes[0]

--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -5,13 +5,13 @@ import sublime_plugin
 
 ST3 = int(sublime.version()) >= 3000
 if ST3:
+    from .git_gutter_settings import settings
     from .view_collection import ViewCollection
     from .git_gutter_popup import show_diff_popup
-    from .git_gutter_settings import GitGutterSettings
 else:
+    from git_gutter_settings import settings
     from view_collection import ViewCollection
     from git_gutter_popup import show_diff_popup
-    from git_gutter_settings import GitGutterSettings
 
 
 def async_event_listener(EventListener):
@@ -37,10 +37,7 @@ def async_event_listener(EventListener):
 
 @async_event_listener
 class GitGutterEvents(sublime_plugin.EventListener):
-
     def __init__(self):
-        self.settings = GitGutterSettings()
-        self.settings.load_settings()
         self.latest_keypresses = {}
 
     # Synchronous
@@ -69,10 +66,10 @@ class GitGutterEvents(sublime_plugin.EventListener):
         # don't let the popup flicker / fight with other packages
         if view.is_popup_visible():
             return
-        if not self.settings.get("enable_hover_diff_popup"):
+        if not settings.get("enable_hover_diff_popup"):
             return
         show_diff_popup(
-            view, point, self.settings, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY)
+            view, point, settings, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY)
 
     # Asynchronous
 
@@ -92,17 +89,17 @@ class GitGutterEvents(sublime_plugin.EventListener):
             else:
                 set_timeout = sublime.set_timeout
 
-            set_timeout(callback, self.settings.get("debounce_delay"))
+            set_timeout(callback, settings.get("debounce_delay"))
         else:
             func(view)
 
     # Settings
 
     def live_mode(self, default=True):
-        return self.settings.get('live_mode', default)
+        return settings.get('live_mode', default)
 
     def focus_change_mode(self, default=True):
-        return self.settings.get('focus_change_mode', default)
+        return settings.get('focus_change_mode', default)
 
     def non_blocking(self, default=True):
-        return self.settings.get('non_blocking', default)
+        return settings.get('non_blocking', default)

--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -68,8 +68,7 @@ class GitGutterEvents(sublime_plugin.EventListener):
             return
         if not settings.get("enable_hover_diff_popup"):
             return
-        show_diff_popup(
-            view, point, settings, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY)
+        show_diff_popup(view, point, flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY)
 
     # Asynchronous
 

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -2,24 +2,22 @@ import os
 import subprocess
 import re
 import codecs
-import shutil
 
 import sublime
 
-ST3 = int(sublime.version()) >= 3006
-
 try:
     from . import git_helper
+    from .git_gutter_settings import settings
     from .view_collection import ViewCollection
 except (ImportError, ValueError):
     import git_helper
+    from git_gutter_settings import settings
     from view_collection import ViewCollection
 
 
 class GitGutterHandler:
-    def __init__(self, view, settings):
+    def __init__(self, view):
         self.view = view
-        self.settings = settings
 
         self.git_temp_file = ViewCollection.git_tmp_file(self.view)
         self.buf_temp_file = ViewCollection.buf_tmp_file(self.view)
@@ -97,7 +95,7 @@ class GitGutterHandler:
                 pass
 
             args = [
-                self.settings.git_binary_path,
+                settings.git_binary_path,
                 '--git-dir=' + self.git_dir,
                 '--work-tree=' + self.git_tree,
                 'show',
@@ -155,10 +153,10 @@ class GitGutterHandler:
             self.update_git_file()
             self.update_buf_file()
             args = [
-                self.settings.git_binary_path,
+                settings.git_binary_path,
                 'diff', '-U0', '--no-color', '--no-index',
-                self.settings.ignore_whitespace,
-                self.settings.patience_switch,
+                settings.ignore_whitespace,
+                settings.patience_switch,
                 self.git_temp_file,
                 self.buf_temp_file,
             ]
@@ -218,7 +216,7 @@ class GitGutterHandler:
                      if line.startswith("-")]
 
             # if wrap is disable avoid wrapping
-            wrap = self.settings.get('next_prev_change_wrap', True)
+            wrap = settings.get('next_prev_change_wrap', True)
             if not wrap:
                 if prev_change is None:
                     prev_change = start
@@ -269,7 +267,7 @@ class GitGutterHandler:
     def handle_files(self, additionnal_args):
         if self.on_disk() and self.git_path:
             args = [
-                self.settings.git_binary_path,
+                settings.git_binary_path,
                 '--git-dir=' + self.git_dir,
                 '--work-tree=' + self.git_tree,
                 'ls-files', '--other', '--exclude-standard',
@@ -289,7 +287,7 @@ class GitGutterHandler:
 
     def git_commits(self):
         args = [
-            self.settings.git_binary_path,
+            settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'log', '--all',
@@ -301,7 +299,7 @@ class GitGutterHandler:
 
     def git_branches(self):
         args = [
-            self.settings.git_binary_path,
+            settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'for-each-ref',
@@ -314,7 +312,7 @@ class GitGutterHandler:
 
     def git_tags(self):
         args = [
-            self.settings.git_binary_path,
+            settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'show-ref',
@@ -326,7 +324,7 @@ class GitGutterHandler:
 
     def git_current_branch(self):
         args = [
-            self.settings.git_binary_path,
+            settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'rev-parse',

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -17,12 +17,10 @@ except (ImportError, ValueError):
 
 
 class GitGutterHandler:
-    git_binary_path_error_shown = False
-    git_binary_path_fallback = None
-
-    def __init__(self, view):
-        self.load_settings()
+    def __init__(self, view, settings):
         self.view = view
+        self.settings = settings
+
         self.git_temp_file = ViewCollection.git_tmp_file(self.view)
         self.buf_temp_file = ViewCollection.buf_tmp_file(self.view)
         self.git_tree = None
@@ -90,7 +88,6 @@ class GitGutterHandler:
 
             f.write(contents)
 
-
     def update_git_file(self):
         # the git repo won't change that often
         # so we can easily wait 5 seconds
@@ -100,7 +97,7 @@ class GitGutterHandler:
                 pass
 
             args = [
-                self.git_binary_path,
+                self.settings.git_binary_path,
                 '--git-dir=' + self.git_dir,
                 '--work-tree=' + self.git_tree,
                 'show',
@@ -158,9 +155,10 @@ class GitGutterHandler:
             self.update_git_file()
             self.update_buf_file()
             args = [
-                self.git_binary_path, 'diff', '-U0', '--no-color', '--no-index',
-                self.ignore_whitespace,
-                self.patience_switch,
+                self.settings.git_binary_path,
+                'diff', '-U0', '--no-color', '--no-index',
+                self.settings.ignore_whitespace,
+                self.settings.patience_switch,
                 self.git_temp_file,
                 self.buf_temp_file,
             ]
@@ -271,7 +269,7 @@ class GitGutterHandler:
     def handle_files(self, additionnal_args):
         if self.on_disk() and self.git_path:
             args = [
-                self.git_binary_path,
+                self.settings.git_binary_path,
                 '--git-dir=' + self.git_dir,
                 '--work-tree=' + self.git_tree,
                 'ls-files', '--other', '--exclude-standard',
@@ -291,7 +289,7 @@ class GitGutterHandler:
 
     def git_commits(self):
         args = [
-            self.git_binary_path,
+            self.settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'log', '--all',
@@ -303,7 +301,7 @@ class GitGutterHandler:
 
     def git_branches(self):
         args = [
-            self.git_binary_path,
+            self.settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'for-each-ref',
@@ -316,7 +314,7 @@ class GitGutterHandler:
 
     def git_tags(self):
         args = [
-            self.git_binary_path,
+            self.settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'show-ref',
@@ -328,7 +326,7 @@ class GitGutterHandler:
 
     def git_current_branch(self):
         args = [
-            self.git_binary_path,
+            self.settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'rev-parse',
@@ -346,70 +344,3 @@ class GitGutterHandler:
         proc = subprocess.Popen(args, stdout=subprocess.PIPE,
                                 startupinfo=startupinfo, stderr=subprocess.PIPE)
         return proc.stdout.read()
-
-    def load_settings(self):
-        self.settings = sublime.load_settings('GitGutter.sublime-settings')
-        self.user_settings = sublime.load_settings(
-            'Preferences.sublime-settings')
-
-        # Git Binary Setting
-        git_binary_setting = self.user_settings.get("git_binary") or \
-                             self.settings.get("git_binary")
-        if isinstance(git_binary_setting, dict):
-            self.git_binary_path = git_binary_setting.get(sublime.platform())
-            if not self.git_binary_path:
-                self.git_binary_path = git_binary_setting.get('default')
-        else:
-            self.git_binary_path = git_binary_setting
-
-        if self.git_binary_path:
-            self.git_binary_path = os.path.expandvars(self.git_binary_path)
-        elif self.git_binary_path_fallback:
-            self.git_binary_path = self.git_binary_path_fallback
-        elif ST3:
-            self.git_binary_path = shutil.which("git")
-            GitGutterHandler.git_binary_path_fallback = self.git_binary_path
-        else:
-            git_exe = "git.exe" if sublime.platform() == "windows" else "git"
-            for folder in os.environ["PATH"].split(os.pathsep):
-                path = os.path.join(folder.strip('"'), git_exe)
-                if os.path.isfile(path) and os.access(path, os.X_OK):
-                    self.git_binary_path = path
-                    GitGutterHandler.git_binary_path_fallback = path
-                    break
-
-        if not self.git_binary_path:
-            if not GitGutterHandler.git_binary_path_error_shown:
-                GitGutterHandler.git_binary_path_error_shown = True
-                msg = ("Your Git binary cannot be found.  If it is installed, add it "
-                       "to your PATH environment variable, or add a `git_binary` setting "
-                       "in the `User/GitGutter.sublime-settings` file.")
-                sublime.error_message(msg)
-                raise ValueError("Git binary not found.")
-
-        # Ignore White Space Setting
-        self.ignore_whitespace = self.settings.get('ignore_whitespace')
-        if self.ignore_whitespace == 'all':
-            self.ignore_whitespace = '-w'
-        elif self.ignore_whitespace == 'eol':
-            self.ignore_whitespace = '--ignore-space-at-eol'
-        else:
-            self.ignore_whitespace = ''
-
-        # Patience Setting
-        self.patience_switch = ''
-        patience = self.settings.get('patience')
-        if patience:
-            self.patience_switch = '--patience'
-
-        # Untracked files
-        self.show_untracked = self.settings.get(
-            'show_markers_on_untracked_file')
-
-        # Show in minimap
-        self.show_in_minimap = self.user_settings.get('show_in_minimap') or self.settings.get('show_in_minimap')
-
-        # Show information in status bar
-        self.show_status = self.user_settings.get('show_status') or self.settings.get('show_status')
-        if self.show_status != 'all' and self.show_status != 'none':
-            self.show_status = 'default'

--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -11,16 +11,16 @@ except:
     _MDPOPUPS_INSTALLED = False
 
 try:
-    from .git_gutter_settings import GitGutterSettings
+    from .git_gutter_settings import settings
     from .view_collection import ViewCollection
 except (ImportError, ValueError):
-    from git_gutter_settings import GitGutterSettings
+    from git_gutter_settings import settings
     from view_collection import ViewCollection
 
 _MD_POPUPS_USE_WRAPPER_CLASS = int(sublime.version()) >= 3119
 
 
-def show_diff_popup(view, point, settings, flags=0):
+def show_diff_popup(view, point, flags=0):
     if not _MDPOPUPS_INSTALLED:
         return
 
@@ -173,11 +173,6 @@ class GitGutterReplaceTextCommand(sublime_plugin.TextCommand):
 
 
 class GitGutterDiffPopupCommand(sublime_plugin.WindowCommand):
-    def __init__(self, *args, **kwargs):
-        sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
-        self.settings = GitGutterSettings()
-        self.settings.load_settings()
-
     def is_enabled(self):
         if not _MDPOPUPS_INSTALLED:
             return False
@@ -188,4 +183,4 @@ class GitGutterDiffPopupCommand(sublime_plugin.WindowCommand):
         if len(view.sel()) == 0:
             return
         point = view.sel()[0].b
-        show_diff_popup(view, point, self.settings, flags=0)
+        show_diff_popup(view, point, flags=0)

--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -84,7 +84,7 @@ def show_diff_popup(view, point, flags=0):
 
             def show_new_popup():
                 if view.visible_region().contains(pt):
-                    show_diff_popup(view, pt, settings, flags=flags)
+                    show_diff_popup(view, pt, flags=flags)
                 else:
                     sublime.set_timeout(show_new_popup, 10)
             view.show_at_center(pt)

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -19,11 +19,6 @@ class GitGutterSettings:
         self._settings = None
         self._user_settings = None
         self._git_binary_path_fallback = None
-        # a mapping of git_dir to a string indicating what to compare against.
-        # ex:
-        #   /Users/foo/workspace1/.git -> "origin",
-        #   /Users/foo/workspace2/.git -> "HEAD"
-        self._compare_against_mapping = {}
         # These settings have public getters as they go through more
         # complex initialization than just getting the value from settings.
         self.git_binary_path = None
@@ -106,14 +101,6 @@ class GitGutterSettings:
             self._settings.get('show_status')
         if self.show_status != 'all' and self.show_status != 'none':
             self.show_status = 'default'
-
-    def get_compare_against(self, git_dir):
-        if git_dir in self._compare_against_mapping:
-            return self._compare_against_mapping[git_dir]
-        return self.get('git_gutter_compare_against', 'HEAD')
-
-    def set_compare_against(self, git_dir, new_compare_against):
-        self._compare_against_mapping[git_dir] = new_compare_against
 
 settings = GitGutterSettings()
 

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -43,8 +43,9 @@ class GitGutterSettings:
             'Preferences.sublime-settings')
 
         # Git Binary Setting
-        git_binary_setting = self._user_settings.get("git_binary") or \
-            self._settings.get("git_binary")
+        git_binary_setting = (
+            self._user_settings.get("git_binary") or
+            self._settings.get("git_binary"))
         if isinstance(git_binary_setting, dict):
             self.git_binary_path = git_binary_setting.get(sublime.platform())
             if not self.git_binary_path:
@@ -93,12 +94,14 @@ class GitGutterSettings:
             self.patience_switch = '--patience'
 
         # Show in minimap
-        self.show_in_minimap = self._user_settings.get('show_in_minimap') or \
-            self._settings.get('show_in_minimap')
+        self.show_in_minimap = (
+            self._user_settings.get('show_in_minimap') or
+            self._settings.get('show_in_minimap'))
 
         # Show information in status bar
-        self.show_status = self._user_settings.get('show_status') or \
-            self._settings.get('show_status')
+        self.show_status = (
+            self._user_settings.get('show_status') or
+            self._settings.get('show_status'))
         if self.show_status != 'all' and self.show_status != 'none':
             self.show_status = 'default'
 

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -1,0 +1,109 @@
+import shutil
+import sublime
+
+ST3 = int(sublime.version()) >= 3006
+
+
+class GitGutterSettings:
+    git_binary_path_error_shown = False
+    git_binary_path_fallback = None
+
+    def __init__(self):
+        self._settings = None
+        self._user_settings = None
+        self._git_binary_path_fallback = None
+        # a mapping of git_dir to a string indicating what to compare against.
+        # ex:
+        #   /Users/foo/workspace1/.git -> "origin",
+        #   /Users/foo/workspace2/.git -> "HEAD"
+        self._compare_against_mapping = {}
+        # These settings have public getters as they go through more
+        # complex initialization than just getting the value from settings.
+        self.git_binary_path = None
+        self.ignore_whitespace = False
+        self.patience_switch = ''
+        self.show_in_minimap = False
+        self.show_status = 'none'
+
+    def get(self, key, default=None):
+        if self._settings is None or not self._settings.has(key):
+            self.load_settings()
+        return self._settings.get(key, default)
+
+    def set(self, key, value):
+        if self._settings is None:
+            self.load_settings()
+        return self._settings.set(key, value)
+
+    def load_settings(self):
+        self._settings = sublime.load_settings('GitGutter.sublime-settings')
+        self._user_settings = sublime.load_settings(
+            'Preferences.sublime-settings')
+
+        # Git Binary Setting
+        git_binary_setting = self._user_settings.get("git_binary") or \
+            self._settings.get("git_binary")
+        if isinstance(git_binary_setting, dict):
+            self.git_binary_path = git_binary_setting.get(sublime.platform())
+            if not self.git_binary_path:
+                self.git_binary_path = git_binary_setting.get('default')
+        else:
+            self.git_binary_path = git_binary_setting
+
+        if self.git_binary_path:
+            self.git_binary_path = os.path.expandvars(self.git_binary_path)
+        elif self._git_binary_path_fallback:
+            self.git_binary_path = self._git_binary_path_fallback
+        elif ST3:
+            self.git_binary_path = shutil.which("git")
+            GitGutterSettings.git_binary_path_fallback = self.git_binary_path
+        else:
+            git_exe = "git.exe" if sublime.platform() == "windows" else "git"
+            for folder in os.environ["PATH"].split(os.pathsep):
+                path = os.path.join(folder.strip('"'), git_exe)
+                if os.path.isfile(path) and os.access(path, os.X_OK):
+                    self.git_binary_path = path
+                    GitGutterSettings.git_binary_path_fallback = path
+                    break
+
+        if not self.git_binary_path:
+            if not GitGutterSettings.git_binary_path_error_shown:
+                GitGutterSettings.git_binary_path_error_shown = True
+                msg = ("Your Git binary cannot be found. If it is installed, "
+                       "add it to your PATH environment variable, or add "
+                       "a `git_binary` setting in the "
+                       "`User/GitGutter.sublime-settings` file.")
+                sublime.error_message(msg)
+                raise ValueError("Git binary not found.")
+
+        # Ignore White Space Setting
+        self.ignore_whitespace = self._settings.get('ignore_whitespace')
+        if self.ignore_whitespace == 'all':
+            self.ignore_whitespace = '-w'
+        elif self.ignore_whitespace == 'eol':
+            self.ignore_whitespace = '--ignore-space-at-eol'
+        else:
+            self.ignore_whitespace = ''
+
+        # Patience Setting
+        self.patience_switch = ''
+        if self._settings.get('patience'):
+            self.patience_switch = '--patience'
+
+        # Show in minimap
+        self.show_in_minimap = self._user_settings.get('show_in_minimap') or \
+            self._settings.get('show_in_minimap')
+
+        # Show information in status bar
+        self.show_status = self._user_settings.get('show_status') or \
+            self._settings.get('show_status')
+        if self.show_status != 'all' and self.show_status != 'none':
+            self.show_status = 'default'
+
+    def get_compare_against(self, git_dir):
+        if git_dir in self._compare_against_mapping:
+            return self._compare_against_mapping[git_dir]
+        return self.get('git_gutter_compare_against', 'HEAD')
+
+    def set_compare_against(self, git_dir, new_compare_against):
+        self._compare_against_mapping[git_dir] = new_compare_against

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import sublime
 

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -2,7 +2,13 @@ import os
 import shutil
 import sublime
 
-ST3 = int(sublime.version()) >= 3006
+ST3 = int(sublime.version()) >= 3000
+
+settings = None
+
+
+def plugin_loaded():
+    settings.load_settings()
 
 
 class GitGutterSettings:
@@ -108,3 +114,8 @@ class GitGutterSettings:
 
     def set_compare_against(self, git_dir, new_compare_against):
         self._compare_against_mapping[git_dir] = new_compare_against
+
+settings = GitGutterSettings()
+
+if not ST3:
+    plugin_loaded()

--- a/view_collection.py
+++ b/view_collection.py
@@ -4,24 +4,9 @@ import tempfile
 import time
 
 try:
-    from .git_gutter_settings import GitGutterSettings
+    from .git_gutter_settings import settings
 except (ImportError, ValueError):
-    from git_gutter_settings import GitGutterSettings
-
-
-ST3 = int(sublime.version()) >= 3000
-
-# Temporary global. Will be removed soon together with ViewCollection.
-settings = None
-
-
-def plugin_loaded():
-    global settings
-    settings = GitGutterSettings()
-    settings.load_settings()
-
-if not ST3:
-    plugin_loaded()
+    from git_gutter_settings import settings
 
 
 class ViewCollection:
@@ -38,7 +23,7 @@ class ViewCollection:
             from .git_gutter_handler import GitGutterHandler
         except (ImportError, ValueError):
             from git_gutter_handler import GitGutterHandler
-        handler = ViewCollection.views[key] = GitGutterHandler(view, settings)
+        handler = ViewCollection.views[key] = GitGutterHandler(view)
         handler.reset()
         return handler
 

--- a/view_collection.py
+++ b/view_collection.py
@@ -3,6 +3,21 @@ import sublime
 import tempfile
 import time
 
+try:
+    from .git_gutter_settings import GitGutterSettings
+except (ImportError, ValueError):
+    from git_gutter_settings import GitGutterSettings
+
+# Temporary global. Will be removed soon together with ViewCollection.
+settings = None
+
+
+def plugin_loaded():
+    global settings
+    settings = GitGutterSettings()
+    settings.load_settings()
+
+
 class ViewCollection:
     views = {} # Todo: these aren't really views but handlers. Refactor/Rename.
     git_times = {}
@@ -17,7 +32,7 @@ class ViewCollection:
             from .git_gutter_handler import GitGutterHandler
         except (ImportError, ValueError):
             from git_gutter_handler import GitGutterHandler
-        handler = ViewCollection.views[key] = GitGutterHandler(view)
+        handler = ViewCollection.views[key] = GitGutterHandler(view, settings)
         handler.reset()
         return handler
 
@@ -124,10 +139,4 @@ class ViewCollection:
 
     @staticmethod
     def show_status(view):
-        key = ViewCollection.get_key(view)
-        return ViewCollection.views[key].show_status
-
-
-def plugin_loaded():
-    settings = sublime.load_settings('GitGutter.sublime-settings')
-    ViewCollection.compare_against = settings.get('compare_against', 'HEAD')
+        return settings.show_status

--- a/view_collection.py
+++ b/view_collection.py
@@ -8,6 +8,9 @@ try:
 except (ImportError, ValueError):
     from git_gutter_settings import GitGutterSettings
 
+
+ST3 = int(sublime.version()) >= 3000
+
 # Temporary global. Will be removed soon together with ViewCollection.
 settings = None
 
@@ -16,6 +19,9 @@ def plugin_loaded():
     global settings
     settings = GitGutterSettings()
     settings.load_settings()
+
+if not ST3:
+    plugin_loaded()
 
 
 class ViewCollection:


### PR DESCRIPTION
This is first step towards rewrite of the code to have less globals and more
passing of objects around.

Created GitGutterSettings class which is created in ViewCollection and passed
onto GitGutterHandler's created from there.

The goal is to remove the ViewCollection and pass settings directly from the
base *Command class. Currently settings object is still created in a couple of
places (ViewCollection, individual "WindowCommand"s and EventListener). In the
end it will be created only from the base TextCommand and EventListener.