### PR TITLE
Don't make spaces unbreakable with the new mdpopups

### DIFF
--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -125,7 +125,9 @@ def show_diff_popup(view, point, flags=0):
                          for l in lines)
         source_content = "\n".join(l[min_indent:] for l in lines)
         # replace spaces by non-breakable ones to avoid line wrapping
-        source_content = source_content.replace(" ", "\u00A0")
+        # (this has been added to mdpopups in version 1.11.0)
+        if mdpopups.version() < (1, 11, 0):
+            source_content = source_content.replace(" ", "\u00A0")
         button_line = (
             '{hide} '
             '{first_change} {prev_change} {next_change} '


### PR DESCRIPTION
mdpopups converts spaces into non-breakable spaces on its own in version 1.11.0 https://github.com/facelessuser/sublime-markdown-popups/issues/14, so this conversion is not necessary if that version is used.