### PR TITLE
Make sure temporary files are deleted after view is closed (fixes #284)

### DIFF
--- a/git_gutter.py
+++ b/git_gutter.py
@@ -21,10 +21,20 @@ except (ImportError, ValueError):
 class GitGutterCommand(sublime_plugin.TextCommand):
     def __init__(self, *args, **kwargs):
         sublime_plugin.TextCommand.__init__(self, *args, **kwargs)
-        self.git_handler = GitGutterHandler(self.view)
-        self.show_diff_handler = GitGutterShowDiff(self.view, self.git_handler)
+        self.is_valid_view = self.view.settings().get('is_widget') is not True
+        self.git_handler = None
+        self.show_diff_handler = None
+
+    def is_enabled(self, **kwargs):
+        return self.is_valid_view
 
     def run(self, edit, **kwargs):
+        if not self.git_handler:
+            self.git_handler = GitGutterHandler(self.view)
+        if not self.show_diff_handler:
+            self.show_diff_handler = GitGutterShowDiff(
+                self.view, self.git_handler)
+
         if not self.git_handler.on_disk() or not self.git_handler.git_dir:
             return
 

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -35,6 +35,10 @@ class GitGutterHandler(object):
 
         self._last_refresh_time_git_file = 0
 
+    def __del__(self):
+        os.unlink(self.git_temp_file)
+        os.unlink(self.buf_temp_file)
+
     @staticmethod
     def tmp_file():
         '''


### PR DESCRIPTION
Delete temporary files on destruction of GitGutterHandler class. Chosen to
remove them from destructor rather than from on_view_close event as it's more
reliable. During on_view_close event, the git command might still be running so
it might be too early to delete temporary files. This seems to work even when
closing Sublime with many files where git gutter has triggered.

Also:
 - Create GitGutterHandler lazily, when any of the commands is run rather
   than on creating the instance of the GitGutter text command itself. That
   ensures that we only create temporary files when actually needed rather than
   immediately for every view that is open in the editor.
 - Disable GitGutter in all native input fields (for example search field shown
   on pressing ctrl+f). All those views don't need GitGutter for anything.