### PR TITLE
Make "compare to" functionality work per git directory (fixes #327)

### DIFF
--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -39,7 +39,7 @@ class GitGutterCompareCommit(object):
             return
         item = results[selected]
         commit = self.item_to_commit(item)
-        settings.set_compare_against(commit)
+        settings.set_compare_against(self.git_handler.git_dir, commit)
         self.git_handler.clear_git_time()
         self.view.run_command('git_gutter')  # refresh ui
 
@@ -86,7 +86,7 @@ class GitGutterCompareTag(GitGutterCompareCommit):
 
 class GitGutterCompareHead(GitGutterCompareCommit):
     def run(self):
-        settings.set_compare_against('HEAD')
+        settings.set_compare_against(self.git_handler.git_dir, 'HEAD')
         self.git_handler.clear_git_time()
         self.view.run_command('git_gutter')  # refresh ui
 
@@ -96,6 +96,7 @@ class GitGutterCompareOrigin(GitGutterCompareCommit):
         def on_branch_name(branch_name):
             if branch_name:
                 settings.set_compare_against(
+                    self.git_handler.git_dir,
                     'origin/%s' % branch_name.decode("utf-8").strip())
                 self.git_handler.clear_git_time()
                 self.view.run_command('git_gutter')  # refresh ui
@@ -104,5 +105,6 @@ class GitGutterCompareOrigin(GitGutterCompareCommit):
 
 class GitGutterShowCompare(GitGutterCompareCommit):
     def run(self):
-        comparing = settings.get_compare_against(self.view)
+        comparing = settings.get_compare_against(self.git_handler.git_dir,
+                                                 self.view)
         sublime.message_dialog('GitGutter is comparing against: %s' % comparing)

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -129,7 +129,8 @@ class GitGutterHandler(object):
                 '--work-tree=' + self.git_tree,
                 'show',
                 '%s:%s' % (
-                    settings.get_compare_against(self.view), self.git_path),
+                    settings.get_compare_against(self.git_dir, self.view),
+                    self.git_path),
             ]
 
             try:

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -12,13 +12,14 @@ def plugin_loaded():
 
 
 class GitGutterSettings:
-    compare_against = None
 
     def __init__(self):
         self._settings = None
         self._user_settings = None
         self._git_binary_path_fallback = None
         self._git_binary_path_error_shown = False
+        # A mapping from git dir to a string indicating what to compare against.
+        self._compare_against_mapping = {}
         # These settings have public getters as they go through more
         # complex initialization than just getting the value from settings.
         self.git_binary_path = None
@@ -105,18 +106,16 @@ class GitGutterSettings:
         if self.show_status != 'all' and self.show_status != 'none':
             self.show_status = 'default'
 
-    def get_compare_against(self, view):
-        # GitGutterSettings.compare_against overrides both project settings and
-        # plugin settings if set.
-        compare = GitGutterSettings.compare_against
-        if compare:
-            return compare
-        compare = self.get('compare_against', compare)
+    def get_compare_against(self, git_dir, view):
+        # Interactively specified compare target overrides settings.
+        if git_dir in self._compare_against_mapping:
+            return self._compare_against_mapping[git_dir]
+        compare = self.get('compare_against')
         # Project settings override plugin settings if set.
         return view.settings().get('git_gutter_compare_against', compare)
 
-    def set_compare_against(self, new_compare_against):
-        GitGutterSettings.compare_against = new_compare_against
+    def set_compare_against(self, git_dir, new_compare_against):
+        self._compare_against_mapping[git_dir] = new_compare_against
 
 settings = GitGutterSettings()
 

--- a/git_gutter_show_diff.py
+++ b/git_gutter_show_diff.py
@@ -82,7 +82,9 @@ class GitGutterShowDiff(object):
             def update_status_ui(branch_name):
                 self._update_status(
                     len(inserted), len(modified), len(deleted),
-                    settings.get_compare_against(self.view), branch_name)
+                    settings.get_compare_against(
+                        self.git_handler.git_dir, self.view),
+                    branch_name)
             branch_promise.then(update_status_ui)
         else:
             self._update_status(0, 0, 0, "", "")


### PR DESCRIPTION
Change from "compare to" target being globally applied for all files to
being applied per git repo as only that makes sense.