### PR TITLE
Some usage optimization

### DIFF
--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -61,7 +61,8 @@ class GitGutterEvents(sublime_plugin.EventListener):
         live_mode or focus_change_mode enabled as they would trigger
         git_gutter with the next on_activate() event.
         """
-        if not self.live_mode() and not self.focus_change_mode() or self.is_view_visible(view):
+        if self.is_view_visible(view) or not (
+           self.live_mode() or self.focus_change_mode()):
             self.debounce(view, 'post-save')
 
     def on_activated(self, view):
@@ -113,6 +114,10 @@ class GitGutterEvents(sublime_plugin.EventListener):
         return settings.get('focus_change_mode', default)
 
     def is_view_visible(self, view):
+        """Return true if the view is visible.
+
+        Only an active view of a group is visible.
+        """
         w = view.window()
         return any(view == w.active_view_in_group(g)
                    for g in range(w.num_groups())) if w is not None else False

--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -62,7 +62,7 @@ class GitGutterEvents(sublime_plugin.EventListener):
         git_gutter with the next on_activate() event.
         """
         if self.is_view_visible(view) or not (
-           self.live_mode() or self.focus_change_mode()):
+                self.live_mode() or self.focus_change_mode()):
             self.debounce(view, 'post-save')
 
     def on_activated(self, view):

--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -61,7 +61,7 @@ class GitGutterEvents(sublime_plugin.EventListener):
         live_mode or focus_change_mode enabled as they would trigger
         git_gutter with the next on_activate() event.
         """
-        if not self.change_mode() or self.is_view_visible(view):
+        if not self.live_mode() and not self.focus_change_mode() or self.is_view_visible(view):
             self.debounce(view, 'post-save')
 
     def on_activated(self, view):
@@ -70,7 +70,7 @@ class GitGutterEvents(sublime_plugin.EventListener):
         This event is also called after a file is opened into an
         active view.
         """
-        if self.change_mode():
+        if self.live_mode() or self.focus_change_mode():
             self.debounce(view, 'activated')
 
     def on_hover(self, view, point, hover_zone):
@@ -112,15 +112,7 @@ class GitGutterEvents(sublime_plugin.EventListener):
     def focus_change_mode(self, default=True):
         return settings.get('focus_change_mode', default)
 
-    def change_mode(self):
-        return self.live_mode() or self.focus_change_mode()
-
     def is_view_visible(self, view):
-        """Return true if the view is visible.
-
-        Only an active view of a group is visible.
-        Note: this should be part of the View class but it isn't.
-        """
         w = view.window()
         return any(view == w.active_view_in_group(g)
                    for g in range(w.num_groups())) if w is not None else False

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -81,8 +81,8 @@ class GitGutterHandler(object):
 
     def on_disk(self):
         # if the view is saved to disk
-        fn = self.view.file_name()
-        on_disk = (fn is not None) and os.path.exists(fn)
+        file_name = self.view.file_name()
+        on_disk = file_name is not None and os.path.isfile(file_name)
         if on_disk:
             self.git_tree = self.git_tree or git_helper.git_tree(self.view)
             self.git_dir = self.git_dir or git_helper.git_dir(self.git_tree)

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -323,13 +323,13 @@ class GitGutterHandler(object):
                 If the view's file is not part of the index
                 git returns empty output to stdout.
                 """
-                return bool(results[1])
+                return bool(results)
 
             args = [
                 settings.git_binary_path,
                 '--git-dir=' + self.git_dir,
                 '--work-tree=' + self.git_tree,
-                'ls-files', '--other', '--exclude-standard'
+                'ls-files', '--other', '--exclude-standard',
             ] + additional_args + [
                 os.path.join(self.git_tree, self.git_path),
             ]

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -81,7 +81,8 @@ class GitGutterHandler(object):
 
     def on_disk(self):
         # if the view is saved to disk
-        on_disk = os.path.exists(self.view.file_name())
+        fn = self.view.file_name()
+        on_disk = (fn is not None) and os.path.exists(fn)
         if on_disk:
             self.git_tree = self.git_tree or git_helper.git_tree(self.view)
             self.git_dir = self.git_dir or git_helper.git_dir(self.git_tree)

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -81,7 +81,7 @@ class GitGutterHandler(object):
 
     def on_disk(self):
         # if the view is saved to disk
-        on_disk = self.view.file_name() is not None
+        on_disk = os.path.exists(self.view.file_name())
         if on_disk:
             self.git_tree = self.git_tree or git_helper.git_tree(self.view)
             self.git_dir = self.git_dir or git_helper.git_dir(self.git_tree)

--- a/git_gutter_jump_to_changes.py
+++ b/git_gutter_jump_to_changes.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-import sublime_plugin
-
 try:
     from .git_gutter_settings import settings
 except (ImportError, ValueError):

--- a/git_gutter_show_diff.py
+++ b/git_gutter_show_diff.py
@@ -21,14 +21,16 @@ class GitGutterShowDiff(object):
         self.view = view
         self.git_handler = git_handler
         self.diff_results = None
+        self.show_untracked = False
 
     def run(self):
         self.git_handler.diff().then(self._check_ignored_or_untracked)
 
     def _check_ignored_or_untracked(self, contents):
-        show_untracked = settings.get(
-            'show_markers_on_untracked_file', False)
         if self._are_all_lines_added(contents):
+            show_untracked = settings.get(
+                'show_markers_on_untracked_file', False)
+            # need to check for ignored or untracked file
             if show_untracked:
                 def bind_ignored_or_untracked(is_ignored):
                     if is_ignored:
@@ -39,20 +41,29 @@ class GitGutterShowDiff(object):
                                 self._bind_files('untracked')
                             else:
                                 self._lazy_update_ui(contents)
+
                         self.git_handler.untracked().then(bind_untracked)
 
                 self.git_handler.ignored().then(bind_ignored_or_untracked)
-            else:
+
+            # show_untracked was set to false recently so clear gutter
+            elif self.show_untracked:
                 self._clear_all()
+                self._update_status(0, 0, 0, "", "")
+
+            self.show_untracked = show_untracked
+
         else:
             self._lazy_update_ui(contents)
 
-    # heuristic to determine if the file is either untracked or ignored: all
-    # lines show up as "inserted" in the diff. Relying on the output of the
-    # normal diff command to trigger the actual untracked / ignored check (which
-    # is expensive because it's two separate git ls-files calls) allows us to
-    # save the extra git calls
     def _are_all_lines_added(self, contents):
+        """Heuristic to determine if the file is either untracked or ignored.
+
+        All lines show up as "inserted" in the diff. Relying on the output of
+        the normal diff command to trigger the actual untracked / ignored check
+        (which is expensive because it's two separate git ls-files calls)
+        allows us to save the extra git calls
+        """
         inserted, modified, deleted = contents
         if len(modified) == 0 and len(deleted) == 0:
             chars = self.view.size()
@@ -62,7 +73,7 @@ class GitGutterShowDiff(object):
             return False
 
     def _lazy_update_ui(self, contents):
-        if self.diff_results is None or self.diff_results != contents:
+        if self.diff_results != contents:
             self.diff_results = contents
             self._update_ui(contents)
 


### PR DESCRIPTION
Hello guys, very much thanks for your incredible good work with GitGutter 1.4.0. 

A also made up my mind how to improve this plug-in a little bit and found two things I would like to discuss or already started to in the issues section.

Sorry for I was not yet able to distinguish the commits to make a pull request for each.

1. Create temp files only for views, whose content is stored in a git repository. (trivial minor improvement)
2. Run Git and diff only if necessary and avoid running it twice.

I think it's better to talk about real code, than generally discuss things. I know there are some concerns about the second probosal and I am sure it needs extensive testing before productive use, but I think it could generally help saving some CPU in the background.

The basic idea behind it is to let git_gutter run only for visible views if live_mode or focus_change_mode are active as git_gutter will run for each view being activated anyway.

I was already able to prevent git_gutter from running 100 times when doing a search and replace in files with this commit and did not find significant issues with gutter not being updated for none active but visible views. 

Hope you are willing to test and discuss it. :-)

