### PR TITLE
Create only one instance of GitGutterSettings (fixes #334)

### DIFF
--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -4,8 +4,6 @@ import sublime
 
 ST3 = int(sublime.version()) >= 3000
 
-settings = None
-
 
 def plugin_loaded():
     settings.load_settings()
@@ -118,7 +116,7 @@ class GitGutterSettings:
     def set_compare_against(self, new_compare_against):
         GitGutterSettings.compare_against = new_compare_against
 
-settings = GitGutterSettings()
-
-if not ST3:
-    plugin_loaded()
+if 'settings' not in globals():
+    settings = GitGutterSettings()
+    if not ST3:
+        plugin_loaded()


### PR DESCRIPTION
It's important that all code shares the same instance of GitGutterSettings.
One reason that this is needed is when we trigger an error on not finding
a git binary. With multiple instances, all will check their own state
of _git_binary_path_error_shown property and we'll end up with multiple
message dialogs.

Fix by checking globals and avoiding creation of GitGutterSettings instance
if it already exists. This is needed as importing git_gutter_settings.py
always re-evaluates the code and that ended up creating new instances.