### PR TITLE
Let user show/hide markers on new, ignored and untracked files

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -57,7 +57,7 @@
   "ignore_whitespace": "none",
 
   // Add a special marker on untracked files
-  "show_markers_on_untracked_file": false,
+  "show_markers_on_untracked_file": true,
 
   // Add --patience switch to git diff command. See
   // http://bramcohen.livejournal.com/73318.html for

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -32,6 +32,7 @@ class GitGutterHandler(object):
         self.git_tree = None
         self.git_dir = None
         self.git_path = None
+        self.git_tracked = False
 
         self._last_refresh_time_git_file = 0
 
@@ -82,6 +83,14 @@ class GitGutterHandler(object):
         origin_encoding = self.view.settings().get('origin_encoding')
         return origin_encoding or encoding
 
+    def in_repo(self):
+        """Return true, if the most recent `git show` returned any content.
+
+        If `git show` returns empty content, any diff will result in
+        all lines added state and the view's file is most commonly untracked.
+        """
+        return self.git_tracked
+
     def on_disk(self):
         """Determine, if the view is saved to disk."""
         file_name = self.view.file_name()
@@ -125,6 +134,7 @@ class GitGutterHandler(object):
         def write_file(contents):
             contents = contents.replace(b'\r\n', b'\n')
             contents = contents.replace(b'\r', b'\n')
+            self.git_tracked = bool(contents)
             with open(self.git_temp_file, 'wb') as f:
                 f.write(contents)
 

--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -22,12 +22,10 @@ _MD_POPUPS_USE_WRAPPER_CLASS = int(sublime.version()) >= 3119
 
 
 def show_diff_popup(view, point, git_handler, highlight_diff=False, flags=0):
-    if not _MDPOPUPS_INSTALLED:
-        return
-
-    line = view.rowcol(point)[0] + 1
-    git_handler.diff_line_change(line).then(
-        partial(_show_diff_popup_impl, view, point, highlight_diff, flags))
+    if _MDPOPUPS_INSTALLED and git_handler.in_repo():
+        line = view.rowcol(point)[0] + 1
+        git_handler.diff_line_change(line).then(
+            partial(_show_diff_popup_impl, view, point, highlight_diff, flags))
 
 
 def _show_diff_popup_impl(view, point, highlight_diff, flags, diff_info):


### PR DESCRIPTION
The documentation of `show_markers_on_untracked_file` setting quite clearly says: "GitGutter shows icons for new files and ignored files." 

GitGutter 1.3.0 did behave exactly like documented.
> git diff is called only for files, which are not marked untracked or ignored.

GitGutter 1.4.0 shows '+' markers on each line for any file within a git repository even with `show_markers_on_untracked_file: false`.
> git diff is called first and then a check is performed, whether the file might be untracked or ignored.

This pull request intends to revert the behaviour to as it was on 1.3.0 to satisfy documentation.

`show_markers_on_untracked_file: false`
	-> do not show any marker on ignored, untracked or new files.

`show_markers_on_untracked_file: true` (Default)
	-> show '*' for untracked files
	-> show 'x' for ignored files
	-> show '+' for new files