### PR TITLE
Enhancement for 'Comparing against' system

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -6,6 +6,7 @@
     { "keys": ["ctrl+shift+alt+c", "h"], "command": "git_gutter_compare_head" },
     { "keys": ["ctrl+shift+alt+c", "o"], "command": "git_gutter_compare_origin" },
     { "keys": ["ctrl+shift+alt+c", "c"], "command": "git_gutter_compare_commit" },
+    { "keys": ["ctrl+shift+alt+c", "f"], "command": "git_gutter_compare_file_commit" },
     { "keys": ["ctrl+shift+alt+c", "b"], "command": "git_gutter_compare_branch" },
     { "keys": ["ctrl+shift+alt+c", "t"], "command": "git_gutter_compare_tag" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -6,6 +6,7 @@
     { "keys": ["super+shift+option+c", "h"], "command": "git_gutter_compare_head" },
     { "keys": ["super+shift+option+c", "o"], "command": "git_gutter_compare_origin" },
     { "keys": ["super+shift+option+c", "c"], "command": "git_gutter_compare_commit" },
+    { "keys": ["super+shift+option+c", "f"], "command": "git_gutter_compare_file_commit" },
     { "keys": ["super+shift+option+c", "b"], "command": "git_gutter_compare_branch" },
     { "keys": ["super+shift+option+c", "t"], "command": "git_gutter_compare_tag" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -6,6 +6,7 @@
     { "keys": ["ctrl+shift+alt+c", "h"], "command": "git_gutter_compare_head" },
     { "keys": ["ctrl+shift+alt+c", "o"], "command": "git_gutter_compare_origin" },
     { "keys": ["ctrl+shift+alt+c", "c"], "command": "git_gutter_compare_commit" },
+    { "keys": ["ctrl+shift+alt+c", "f"], "command": "git_gutter_compare_file_commit" },
     { "keys": ["ctrl+shift+alt+c", "b"], "command": "git_gutter_compare_branch" },
     { "keys": ["ctrl+shift+alt+c", "t"], "command": "git_gutter_compare_tag" }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -20,6 +20,10 @@
         "command": "git_gutter_compare_commit"
     },
     {
+        "caption": "GitGutter: Compare Against File Commit",
+        "command": "git_gutter_compare_file_commit"
+    },
+    {
         "caption": "GitGutter: Compare Against Branch",
         "command": "git_gutter_compare_branch"
     },

--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ By default, Git Gutter compares your working copy against the HEAD. You can chan
 - Compare against particular branch
 - Compare against particular tag
 - Compare against specific commit
+- Compare against specific file commit (current file's history)
 
 To change the compare option:
 
 - Open the command palette (`Ctrl-Shift-P` for Windows/Linux, `Cmd-Shift-P` for Mac)
 - Start typing `GitGutter`
-- You'll see the 4 options listed above, select one with the keyboard.
+- You'll see the 5 options listed above, select one with the keyboard.
 - Choose the branch/tag/commit to compare against.
 
 ### Jumping Between Changes

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -4,7 +4,8 @@ try:
     from .git_gutter_handler import GitGutterHandler
     from .git_gutter_compare import (
         GitGutterCompareCommit, GitGutterCompareBranch, GitGutterCompareTag,
-        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare)
+        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare,
+        GitGutterCompareFileCommit)
     from .git_gutter_jump_to_changes import GitGutterJumpToChanges
     from .git_gutter_popup import show_diff_popup
     from .git_gutter_show_diff import GitGutterShowDiff
@@ -12,7 +13,8 @@ except (ImportError, ValueError):
     from git_gutter_handler import GitGutterHandler
     from git_gutter_compare import (
         GitGutterCompareCommit, GitGutterCompareBranch, GitGutterCompareTag,
-        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare)
+        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare,
+        GitGutterCompareFileCommit)
     from git_gutter_jump_to_changes import GitGutterJumpToChanges
     from git_gutter_popup import show_diff_popup
     from git_gutter_show_diff import GitGutterShowDiff
@@ -52,6 +54,8 @@ class GitGutterCommand(TextCommand):
             GitGutterJumpToChanges(self.git_handler).jump_to_prev_change()
         elif action == 'compare_against_commit':
             GitGutterCompareCommit(self.git_handler).run()
+        elif action == 'compare_against_file_commit':
+            GitGutterCompareFileCommit(self.git_handler).run()
         elif action == 'compare_against_branch':
             GitGutterCompareBranch(self.git_handler).run()
         elif action == 'compare_against_tag':
@@ -95,6 +99,12 @@ class GitGutterCompareCommitCommand(TextCommand):
     def run(self, edit):
         self.view.run_command(
             'git_gutter', {'action': 'compare_against_commit'})
+
+
+class GitGutterCompareFileCommitCommand(TextCommand):
+    def run(self, edit):
+        self.view.run_command(
+            'git_gutter', {'action': 'compare_against_file_commit'})
 
 
 class GitGutterCompareBranchCommand(TextCommand):

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -1,4 +1,4 @@
-import sublime_plugin
+from sublime_plugin import TextCommand
 
 try:
     from .git_gutter_handler import GitGutterHandler
@@ -18,9 +18,9 @@ except (ImportError, ValueError):
     from git_gutter_show_diff import GitGutterShowDiff
 
 
-class GitGutterCommand(sublime_plugin.TextCommand):
+class GitGutterCommand(TextCommand):
     def __init__(self, *args, **kwargs):
-        sublime_plugin.TextCommand.__init__(self, *args, **kwargs)
+        TextCommand.__init__(self, *args, **kwargs)
         self.is_valid_view = self.view.settings().get('is_widget') is not True
         self.git_handler = None
         self.show_diff_handler = None
@@ -45,75 +45,77 @@ class GitGutterCommand(sublime_plugin.TextCommand):
         self.show_diff_handler.run()
 
     def _handle_subcommand(self, **kwargs):
-        view = self.view
-        git_handler = self.git_handler
         action = kwargs['action']
         if action == 'jump_to_next_change':
-            GitGutterJumpToChanges(view, git_handler).jump_to_next_change()
+            GitGutterJumpToChanges(self.git_handler).jump_to_next_change()
         elif action == 'jump_to_prev_change':
-            GitGutterJumpToChanges(view, git_handler).jump_to_prev_change()
+            GitGutterJumpToChanges(self.git_handler).jump_to_prev_change()
         elif action == 'compare_against_commit':
-            GitGutterCompareCommit(view, git_handler).run()
+            GitGutterCompareCommit(self.git_handler).run()
         elif action == 'compare_against_branch':
-            GitGutterCompareBranch(view, git_handler).run()
+            GitGutterCompareBranch(self.git_handler).run()
         elif action == 'compare_against_tag':
-            GitGutterCompareTag(view, git_handler).run()
+            GitGutterCompareTag(self.git_handler).run()
         elif action == 'compare_against_head':
-            GitGutterCompareHead(view, git_handler).run()
+            GitGutterCompareHead(self.git_handler).run()
         elif action == 'compare_against_origin':
-            GitGutterCompareOrigin(view, git_handler).run()
+            GitGutterCompareOrigin(self.git_handler).run()
         elif action == 'show_compare':
-            GitGutterShowCompare(view, git_handler).run()
+            GitGutterShowCompare(self.git_handler).run()
         elif action == 'show_diff_popup':
             point = kwargs['point']
             highlight_diff = kwargs['highlight_diff']
             flags = kwargs['flags']
             show_diff_popup(
-                view, point, git_handler, highlight_diff=highlight_diff,
-                flags=flags)
+                point, self.git_handler,
+                highlight_diff=highlight_diff, flags=flags)
         else:
             assert False, 'Unhandled sub command "%s"' % action
 
 
-class GitGutterShowCompareCommand(sublime_plugin.TextCommand):
+class GitGutterShowCompareCommand(TextCommand):
     def run(self, edit):
-        self.view.run_command('git_gutter', {'action': 'show_compare'})
+        self.view.run_command(
+            'git_gutter', {'action': 'show_compare'})
 
 
-class GitGutterCompareHeadCommand(sublime_plugin.TextCommand):
+class GitGutterCompareHeadCommand(TextCommand):
     def run(self, edit):
-        self.view.run_command('git_gutter', {'action': 'compare_against_head'})
+        self.view.run_command(
+            'git_gutter', {'action': 'compare_against_head'})
 
 
-class GitGutterCompareOriginCommand(sublime_plugin.TextCommand):
+class GitGutterCompareOriginCommand(TextCommand):
     def run(self, edit):
         self.view.run_command(
             'git_gutter', {'action': 'compare_against_origin'})
 
 
-class GitGutterCompareCommitCommand(sublime_plugin.TextCommand):
+class GitGutterCompareCommitCommand(TextCommand):
     def run(self, edit):
         self.view.run_command(
             'git_gutter', {'action': 'compare_against_commit'})
 
 
-class GitGutterCompareBranchCommand(sublime_plugin.TextCommand):
+class GitGutterCompareBranchCommand(TextCommand):
     def run(self, edit):
         self.view.run_command(
             'git_gutter', {'action': 'compare_against_branch'})
 
 
-class GitGutterCompareTagCommand(sublime_plugin.TextCommand):
+class GitGutterCompareTagCommand(TextCommand):
     def run(self, edit):
         self.view.run_command(
             'git_gutter', {'action': 'compare_against_tag'})
 
 
-class GitGutterNextChangeCommand(sublime_plugin.TextCommand):
+class GitGutterNextChangeCommand(TextCommand):
     def run(self, edit):
-        self.view.run_command('git_gutter', {'action': 'jump_to_next_change'})
+        self.view.run_command(
+            'git_gutter', {'action': 'jump_to_next_change'})
 
 
-class GitGutterPrevChangeCommand(sublime_plugin.TextCommand):
+class GitGutterPrevChangeCommand(TextCommand):
     def run(self, edit):
-        self.view.run_command('git_gutter', {'action': 'jump_to_prev_change'})
+        self.view.run_command(
+            'git_gutter', {'action': 'jump_to_prev_change'})

--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -2,15 +2,9 @@ from functools import partial
 
 import sublime
 
-try:
-    from .promise import Promise
-except (ImportError, ValueError):
-    from promise import Promise
-
 
 class GitGutterCompareCommit(object):
-    def __init__(self, view, git_handler):
-        self.view = view
+    def __init__(self, git_handler):
         self.git_handler = git_handler
 
     def run(self):
@@ -22,8 +16,6 @@ class GitGutterCompareCommit(object):
                 return [r.split('\a', 2) for r in results.splitlines()]
             sublime.message_dialog('No commits found in repository.')
             return []
-        if not self.git_handler.on_disk():
-            return Promise.resolve([])
         return self.git_handler.git_commits().then(parse_commits)
 
     def item_to_commit(self, item):
@@ -31,7 +23,7 @@ class GitGutterCompareCommit(object):
 
     def _show_quick_panel(self, results):
         if results:
-            self.view.window().show_quick_panel(
+            self.git_handler.view.window().show_quick_panel(
                 results, partial(self._on_select, results))
 
     def _on_select(self, results, selected):
@@ -49,8 +41,6 @@ class GitGutterCompareBranch(GitGutterCompareCommit):
                 return [self._parse_result(r) for r in results.splitlines()]
             sublime.message_dialog('No branches found in repository.')
             return []
-        if not self.git_handler.on_disk():
-            return Promise.resolve([])
         return self.git_handler.git_branches().then(parse_branches)
 
     def _parse_result(self, result):
@@ -71,8 +61,6 @@ class GitGutterCompareTag(GitGutterCompareCommit):
                 return [self._parse_result(r) for r in results.splitlines()]
             sublime.message_dialog('No tags found in repository.')
             return []
-        if not self.git_handler.on_disk():
-            return Promise.resolve([])
         return self.git_handler.git_tags().then(parse_tags)
 
     def _parse_result(self, result):

--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -3,10 +3,8 @@ from functools import partial
 import sublime
 
 try:
-    from .git_gutter_settings import settings
     from .promise import Promise
 except (ImportError, ValueError):
-    from git_gutter_settings import settings
     from promise import Promise
 
 
@@ -19,12 +17,14 @@ class GitGutterCompareCommit(object):
         self.commit_list().then(self._show_quick_panel)
 
     def commit_list(self):
-        def decode_and_parse_commit_list(result):
-            commit_lines = result.splitlines()
-            return [r.split('\a', 2) for r in commit_lines]
+        def parse_commits(results):
+            if results:
+                return [r.split('\a', 2) for r in results.splitlines()]
+            sublime.message_dialog('No commits found in repository.')
+            return []
         if not self.git_handler.on_disk():
             return Promise.resolve([])
-        return self.git_handler.git_commits().then(decode_and_parse_commit_list)
+        return self.git_handler.git_commits().then(parse_commits)
 
     def item_to_commit(self, item):
         return item[1].split(' ')[0]
@@ -39,72 +39,68 @@ class GitGutterCompareCommit(object):
             return
         item = results[selected]
         commit = self.item_to_commit(item)
-        settings.set_compare_against(self.git_handler.git_dir, commit)
-        self.git_handler.clear_git_time()
-        self.view.run_command('git_gutter')  # refresh ui
+        self.git_handler.set_compare_against(commit)
 
 
 class GitGutterCompareBranch(GitGutterCompareCommit):
     def commit_list(self):
-        def decode_and_parse_branch_list(result):
-            branch_lines = result.splitlines()
-            return [self._parse_result(r) for r in branch_lines]
+        def parse_branches(results):
+            if results:
+                return [self._parse_result(r) for r in results.splitlines()]
+            sublime.message_dialog('No branches found in repository.')
+            return []
         if not self.git_handler.on_disk():
             return Promise.resolve([])
-        return self.git_handler.git_branches().then(
-            decode_and_parse_branch_list)
+        return self.git_handler.git_branches().then(parse_branches)
 
     def _parse_result(self, result):
         pieces = result.split('\a')
         message = pieces[0]
-        branch  = pieces[1].split("/", 2)[2]
-        commit  = pieces[2][0:7]
-        return [branch, commit + " " + message]
+        branch = pieces[1][11:]   # skip 'refs/heads/'
+        commit = pieces[2][0:7]   # 7-digit commit hash
+        return [branch, commit + ' ' + message]
+
+    def item_to_commit(self, item):
+        return 'refs/heads/' + item[0]
 
 
 class GitGutterCompareTag(GitGutterCompareCommit):
     def commit_list(self):
-        def decode_and_parse_tag_list(results):
+        def parse_tags(results):
             if results:
-                tag_lines = results.splitlines()
-                return [self._parse_result(r) for r in tag_lines]
-            sublime.message_dialog("No tags found in repository")
+                return [self._parse_result(r) for r in results.splitlines()]
+            sublime.message_dialog('No tags found in repository.')
             return []
         if not self.git_handler.on_disk():
             return Promise.resolve([])
-        return self.git_handler.git_tags().then(decode_and_parse_tag_list)
+        return self.git_handler.git_tags().then(parse_tags)
 
     def _parse_result(self, result):
         pieces = result.split(' ')
-        commit = pieces[0]
-        tag    = pieces[1].replace("refs/tags/", "")
+        commit = pieces[0]     # 7-digit commit hash
+        tag = pieces[1][10:]   # skip 'refs/tags/'
         return [tag, commit]
 
     def item_to_commit(self, item):
-        return item[1]
+        return 'refs/tags/' + item[0]
 
 
 class GitGutterCompareHead(GitGutterCompareCommit):
     def run(self):
-        settings.set_compare_against(self.git_handler.git_dir, 'HEAD')
-        self.git_handler.clear_git_time()
-        self.view.run_command('git_gutter')  # refresh ui
+        self.git_handler.set_compare_against('HEAD', True)
 
 
 class GitGutterCompareOrigin(GitGutterCompareCommit):
     def run(self):
         def on_branch_name(branch_name):
             if branch_name:
-                settings.set_compare_against(
-                    self.git_handler.git_dir,
-                    'origin/%s' % branch_name)
-                self.git_handler.clear_git_time()
-                self.view.run_command('git_gutter')  # refresh ui
+                self.git_handler.set_compare_against(
+                    'origin/' + branch_name, True)
         self.git_handler.git_current_branch().then(on_branch_name)
 
 
 class GitGutterShowCompare(GitGutterCompareCommit):
     def run(self):
-        comparing = settings.get_compare_against(self.git_handler.git_dir,
-                                                 self.view)
-        sublime.message_dialog('GitGutter is comparing against: %s' % comparing)
+        comparing = self.git_handler.format_compare_against()
+        sublime.message_dialog(
+            'GitGutter is comparing against: %s' % comparing)

--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -19,7 +19,7 @@ class GitGutterCompareCommit(object):
         return self.git_handler.git_commits().then(parse_commits)
 
     def item_to_commit(self, item):
-        return item[1].split(' ')[0]
+        return item[0].split(' \u00BB ')[0]
 
     def _show_quick_panel(self, results):
         if results:
@@ -32,6 +32,17 @@ class GitGutterCompareCommit(object):
         item = results[selected]
         commit = self.item_to_commit(item)
         self.git_handler.set_compare_against(commit)
+
+
+class GitGutterCompareFileCommit(GitGutterCompareCommit):
+    def commit_list(self):
+        def parse_file_commits(results):
+            if results:
+                return [r.split('\a', 2) for r in results.splitlines()]
+            sublime.message_dialog(
+               'No commits with reference to the file found in repository.')
+            return []
+        return self.git_handler.git_file_commits().then(parse_file_commits)
 
 
 class GitGutterCompareBranch(GitGutterCompareCommit):

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -54,6 +54,9 @@ class GitGutterHandler(object):
         os.close(fd)
         return filepath
 
+    def git_time_cleared(self):
+        return self._last_refresh_time_git_file == 0
+
     def clear_git_time(self):
         self._last_refresh_time_git_file = 0
 
@@ -62,6 +65,37 @@ class GitGutterHandler(object):
 
     def git_time(self):
         return time.time() - self._last_refresh_time_git_file
+
+    def get_compare_against(self):
+        """Return the branch/commit/tag string the view is compared to."""
+        return settings.get_compare_against(self.git_dir, self.view)
+
+    def set_compare_against(self, commit, refresh=False):
+        """Apply a new branch/commit/tag string the view is compared to.
+
+        If one of the settings 'focus_change_mode' or 'live_mode' is true,
+        the view, is automatically compared by 'on_activate' event when
+        returning from a quick panel and therefore the command 'git_gutter'
+        can be ommited. This assumption can be overriden by 'refresh' for
+        commands that do not show a quick panel.
+
+        Arguments:
+            commit  - is either a branch, commit or tag as returned from
+                      git show-ref
+            refresh - always call git_gutter command
+        """
+        settings.set_compare_against(self.git_dir, commit)
+        self.clear_git_time()
+        if refresh or not any(settings.get(key, True) for key in (
+                'focus_change_mode', 'live_mode')):
+            self.view.run_command('git_gutter')  # refresh ui
+
+    def format_compare_against(self):
+        """Format the compare against setting to use for display."""
+        comparing = self.get_compare_against()
+        for repl in ('refs/heads/', 'refs/remotes/', 'refs/tags/'):
+            comparing = comparing.replace(repl, '')
+        return comparing
 
     def _get_view_encoding(self):
         """Get encoding and clean it for python ex: "Western (ISO 8859-1)".

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -389,8 +389,20 @@ class GitGutterHandler(object):
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'log', '--all',
-            '--pretty=%s\a%h %an <%aE>\a%ad (%ar)',
+            '--pretty=%h \u00BB %s\a%an <%aE>\a%ad (%ar)',
             '--date=local', '--max-count=9000'
+        ]
+        return GitGutterHandler.run_command(args)
+
+    def git_file_commits(self):
+        args = [
+            settings.git_binary_path,
+            '--git-dir=' + self.git_dir,
+            '--work-tree=' + self.git_tree,
+            'log',
+            '--pretty=%h \u00BB %s\a%an <%aE>\a%ad (%ar)',
+            '--date=local', '--max-count=9000',
+            '--', self.git_path
         ]
         return GitGutterHandler.run_command(args)
 

--- a/git_gutter_jump_to_changes.py
+++ b/git_gutter_jump_to_changes.py
@@ -7,8 +7,7 @@ except (ImportError, ValueError):
 
 
 class GitGutterJumpToChanges(object):
-    def __init__(self, view, git_handler):
-        self.view = view
+    def __init__(self, git_handler):
         self.git_handler = git_handler
 
     def lines_to_blocks(self, lines):
@@ -26,10 +25,11 @@ class GitGutterJumpToChanges(object):
         modified = self.lines_to_blocks(modified)
         all_changes = sorted(inserted + modified + deleted)
         if all_changes:
-            row, col = self.view.rowcol(self.view.sel()[0].begin())
+            view = self.git_handler.view
+            row, col = view.rowcol(view.sel()[0].begin())
             current_row = row + 1
             line = jump_func(all_changes, current_row)
-            self.view.run_command("goto_line", {"line": line})
+            view.run_command("goto_line", {"line": line})
 
     def jump_to_next_change(self):
         self.git_handler.diff().then(partial(self.goto_line, self.next_jump))

--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -21,8 +21,9 @@ if _MDPOPUPS_INSTALLED:
 _MD_POPUPS_USE_WRAPPER_CLASS = int(sublime.version()) >= 3119
 
 
-def show_diff_popup(view, point, git_handler, highlight_diff=False, flags=0):
+def show_diff_popup(point, git_handler, highlight_diff=False, flags=0):
     if _MDPOPUPS_INSTALLED and git_handler.in_repo():
+        view = git_handler.view
         line = view.rowcol(point)[0] + 1
         git_handler.diff_line_change(line).then(
             partial(_show_diff_popup_impl, view, point, highlight_diff, flags))

--- a/git_gutter_show_diff.py
+++ b/git_gutter_show_diff.py
@@ -22,6 +22,8 @@ class GitGutterShowDiff(object):
         self.show_untracked = False
 
     def run(self):
+        if self.git_handler.git_time_cleared():
+            self.diff_results = None
         self.git_handler.diff().then(self._check_ignored_or_untracked)
 
     def _check_ignored_or_untracked(self, contents):
@@ -70,8 +72,7 @@ class GitGutterShowDiff(object):
             def update_status_ui(branch_name):
                 self._update_status(
                     len(inserted), len(modified), len(deleted),
-                    settings.get_compare_against(
-                        self.git_handler.git_dir, self.view),
+                    self.git_handler.format_compare_against(),
                     branch_name)
 
             if settings.show_status == 'all':


### PR DESCRIPTION
Hello guys,

I was always confuesed about the `Comparing against: ...` status messages. It always shows HEAD or a commit hash. I never saw the name of a branch selected to compare against. While investigating the performance issue #26 I found the answer and decided to create this pull request. Hope you'll find it as useful as I do.

### Issue
`Comparing against branch` doesn't actually tell GitGutter to compare against the HEAD of the selected branch but only against the currently latest commit. This has two side effects. The branch name is not displayed in the status bar and if the branch forwards, GitGutter won't see that.

### Suggestions
1. Save the whole `refs/heads/...` or `refs/tags/...` strings instead of commit numbers, if `Compare against branch` or `Compare against tag` was called.
2. Suggestion (1) requires updated status message creation in `git_gutter_show_diff`.
3. Overide the _lazy functions to force UI updates, if the compare target changes.
4. I somehow struggled with output decoding of git and found it being required nearly everywhere. As it doesn't need to be part of the Promise chain, I decided to do it directly in the `git_handler.run_command()` method. So by default all output is decoded and we don't need to think about it anymore.

### Remarks
I splitted those suggestions into three commits for better tracking changes, but decided to create one pull request, because merging them seperatly would make things more complicated, I think.

Looking forward to your comments.