### PR TITLE
Fix issue: GitGutter ignores on_modified() event in ST2, because view visibility check fails.

### DIFF
--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -118,6 +118,10 @@ class GitGutterEvents(sublime_plugin.EventListener):
 
         Only an active view of a group is visible.
         """
-        w = view.window()
-        return any(view == w.active_view_in_group(g)
-                   for g in range(w.num_groups())) if w is not None else False
+        window = view.window()
+        if window:
+            view_id = view.id()
+            for group in range(window.num_groups()):
+                if view_id == window.active_view_in_group(group).id():
+                    return True
+        return False

--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -122,6 +122,7 @@ class GitGutterEvents(sublime_plugin.EventListener):
         if window:
             view_id = view.id()
             for group in range(window.num_groups()):
-                if view_id == window.active_view_in_group(group).id():
+                active_view = window.active_view_in_group(group)
+                if active_view and active_view.id() == view_id:
                     return True
         return False


### PR DESCRIPTION
We need to use the view id to check the view is the active one in a group.