### PR TITLE
Enhancements for the "Compare against ..."

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -6,6 +6,7 @@
     { "keys": ["ctrl+shift+alt+c", "h"], "command": "git_gutter_compare_head" },
     { "keys": ["ctrl+shift+alt+c", "o"], "command": "git_gutter_compare_origin" },
     { "keys": ["ctrl+shift+alt+c", "c"], "command": "git_gutter_compare_commit" },
+    { "keys": ["ctrl+shift+alt+c", "f"], "command": "git_gutter_compare_file_commit" },
     { "keys": ["ctrl+shift+alt+c", "b"], "command": "git_gutter_compare_branch" },
     { "keys": ["ctrl+shift+alt+c", "t"], "command": "git_gutter_compare_tag" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -6,6 +6,7 @@
     { "keys": ["super+shift+option+c", "h"], "command": "git_gutter_compare_head" },
     { "keys": ["super+shift+option+c", "o"], "command": "git_gutter_compare_origin" },
     { "keys": ["super+shift+option+c", "c"], "command": "git_gutter_compare_commit" },
+    { "keys": ["super+shift+option+c", "f"], "command": "git_gutter_compare_file_commit" },
     { "keys": ["super+shift+option+c", "b"], "command": "git_gutter_compare_branch" },
     { "keys": ["super+shift+option+c", "t"], "command": "git_gutter_compare_tag" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -6,6 +6,7 @@
     { "keys": ["ctrl+shift+alt+c", "h"], "command": "git_gutter_compare_head" },
     { "keys": ["ctrl+shift+alt+c", "o"], "command": "git_gutter_compare_origin" },
     { "keys": ["ctrl+shift+alt+c", "c"], "command": "git_gutter_compare_commit" },
+    { "keys": ["ctrl+shift+alt+c", "f"], "command": "git_gutter_compare_file_commit" },
     { "keys": ["ctrl+shift+alt+c", "b"], "command": "git_gutter_compare_branch" },
     { "keys": ["ctrl+shift+alt+c", "t"], "command": "git_gutter_compare_tag" }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -20,6 +20,10 @@
         "command": "git_gutter_compare_commit"
     },
     {
+        "caption": "GitGutter: Compare Against File Commit",
+        "command": "git_gutter_compare_file_commit"
+    },
+    {
         "caption": "GitGutter: Compare Against Branch",
         "command": "git_gutter_compare_branch"
     },

--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -64,13 +64,30 @@
   // an example of why you might need this.
   "patience": true,
 
-  // Determines whether GitGutter will show informations in the status bar
-  // Set "none" to hide these informations
-  // Set "default" to show in the status bar what you are comparing
-  // against, how many lines have been inserted or modified and how many regions
-  // have been deleted.
-  // Set "all" to also show on what branch you are
-  "show_status": "default",
+  // Determines whether GitGutter shows status information in the status bar.
+  // Set false to disable status information.
+  // Set true to show information using the "status_bar_text" template.
+  "show_status_bar_text": true,
+
+  // STATUS BAR TEXT TEMPLATE
+  // The array is joined to a single string and passed to jinja2 template
+  // engine to render the status message text. The template can be modified using
+  // jinja2 supported syntax. GitGutter provides the following variables:
+  //   {{repo}}     -- repository name / folder name containing the .git directory
+  //   {{branch}}   -- checked out branch you are working on
+  //   {{compare}}  -- commit/branch/HEAD the file is compared to
+  //   {{state}}    -- One of committed/modified/ignored/untracked
+  //   {{deleted}}  -- number of deleted regions
+  //   {{inserted}} -- number of inserted lines
+  //   {{modified}} -- number of modified lines
+  "status_bar_text": [
+    "In {{repo}} on {{branch}}",
+    "{% if compare != 'HEAD' %}, Comparing against {{compare}}{% endif %}",
+    ", File is {{state}}",
+    "{% if deleted != 0 %}, {{deleted}}-{% endif %}",
+    "{% if inserted != 0 %}, {{inserted}}+{% endif %}",
+    "{% if modified != 0 %}, {{modified}}≠{% endif %}"
+  ],
 
   // Show GitGutter information in the minimap
   "show_in_minimap": true,

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -30,6 +30,10 @@
                                 "command": "git_gutter_compare_commit"
                             },
                             {
+                                "caption": "File Commit",
+                                "command": "git_gutter_compare_file_commit"
+                            },
+                            {
                                 "caption": "Branch",
                                 "command": "git_gutter_compare_branch"
                             },

--- a/README.md
+++ b/README.md
@@ -145,9 +145,39 @@ Is GitGutter blocking SublimeLinter or other icons? You can prevent this by addi
 ```
 You will need to figure out the names of the regions you are trying to protect.
 
+
 #### Status Bar Text
 
-You can turn off the status bar text by changing `"show_status": "default"` to `"show_status": "none"`.
+GitGutter displays status information about open files in the status bar by
+default. To turn this feature off set `"show_status_bar_text": false`.
+
+The *Status Bar Text* is rendered by the powerful *jinja2* engine using the
+template from `"status_bar_text": [...]` setting. The setting is organized as
+an array of strings for better readability. It is joined and then passed to
+*jinja2*. GitGutter provides the following variables to be used in the template.
+
+| Variable     | Description                                                 |
+|--------------|-------------------------------------------------------------|
+| {{repo}}     | repository name / folder name containing the .git directory |
+| {{branch}}   | checked out branch you are working on                       |
+| {{compare}}  | commit/branch/HEAD the file is compared to                  |
+| {{state}}    | One of committed/modified/ignored/untracked                 |
+| {{deleted}}  | number of deleted regions                                   |
+| {{inserted}} | number of inserted lines                                    |
+| {{modified}} | number of modified lines                                    |
+
+##### Example 1 - default template
+
+```javascript
+"status_bar_text": [
+  "In {{repo}} on {{branch}}",
+  "{% if compare != 'HEAD' %}, Comparing against {{compare}}{% endif %}",
+  ", File is {{state}}",
+  "{% if deleted != 0 %}, {{deleted}}-{% endif %}",
+  "{% if inserted != 0 %}, {{inserted}}+{% endif %}",
+  "{% if modified != 0 %}, {{modified}}≠{% endif %}"
+]
+```
 
 
 #### Themes

--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ By default, Git Gutter compares your working copy against the HEAD. You can chan
 - Compare against particular branch
 - Compare against particular tag
 - Compare against specific commit
+- Compare against specific file commit (current file's history)
 
 To change the compare option:
 
 - Open the command palette (`Ctrl-Shift-P` for Windows/Linux, `Cmd-Shift-P` for Mac)
 - Start typing `GitGutter`
-- You'll see the 4 options listed above, select one with the keyboard.
+- You'll see the 5 options listed above, select one with the keyboard.
 - Choose the branch/tag/commit to compare against.
 
 ### Jumping Between Changes

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,11 +1,13 @@
 {
     "*": {
+        "*": [
+            "markupsafe",
+            "python-jinja2"
+        ],
         ">=3080": [
             "pygments",
             "python-markdown",
-            "mdpopups",
-            "python-jinja2",
-            "markupsafe"
+            "mdpopups"
         ]
     }
 }

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -5,7 +5,8 @@ try:
     from .git_gutter_handler import GitGutterHandler
     from .git_gutter_compare import (
         GitGutterCompareCommit, GitGutterCompareBranch, GitGutterCompareTag,
-        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare)
+        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare,
+        GitGutterCompareFileCommit)
     from .git_gutter_jump_to_changes import GitGutterJumpToChanges
     from .git_gutter_popup import show_diff_popup
     from .git_gutter_show_diff import GitGutterShowDiff
@@ -14,7 +15,8 @@ except (ImportError, ValueError):
     from git_gutter_handler import GitGutterHandler
     from git_gutter_compare import (
         GitGutterCompareCommit, GitGutterCompareBranch, GitGutterCompareTag,
-        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare)
+        GitGutterCompareHead, GitGutterCompareOrigin, GitGutterShowCompare,
+        GitGutterCompareFileCommit)
     from git_gutter_jump_to_changes import GitGutterJumpToChanges
     from git_gutter_popup import show_diff_popup
     from git_gutter_show_diff import GitGutterShowDiff
@@ -73,6 +75,8 @@ class GitGutterCommand(TextCommand):
             GitGutterJumpToChanges(self.git_handler).jump_to_prev_change()
         elif action == 'compare_against_commit':
             GitGutterCompareCommit(self.git_handler).run()
+        elif action == 'compare_against_file_commit':
+            GitGutterCompareFileCommit(self.git_handler).run()
         elif action == 'compare_against_branch':
             GitGutterCompareBranch(self.git_handler).run()
         elif action == 'compare_against_tag':
@@ -119,6 +123,12 @@ class GitGutterCompareCommitCommand(GitGutterBaseCommand):
     def run(self, edit):
         self.view.run_command(
             'git_gutter', {'action': 'compare_against_commit'})
+
+
+class GitGutterCompareFileCommitCommand(GitGutterBaseCommand):
+    def run(self, edit):
+        self.view.run_command(
+            'git_gutter', {'action': 'compare_against_file_commit'})
 
 
 class GitGutterCompareBranchCommand(GitGutterBaseCommand):

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -66,32 +66,30 @@ class GitGutterCommand(TextCommand):
             self.show_diff_handler.run()
 
     def _handle_subcommand(self, **kwargs):
-        view = self.view
-        git_handler = self.git_handler
         action = kwargs['action']
         if action == 'jump_to_next_change':
-            GitGutterJumpToChanges(view, git_handler).jump_to_next_change()
+            GitGutterJumpToChanges(self.git_handler).jump_to_next_change()
         elif action == 'jump_to_prev_change':
-            GitGutterJumpToChanges(view, git_handler).jump_to_prev_change()
+            GitGutterJumpToChanges(self.git_handler).jump_to_prev_change()
         elif action == 'compare_against_commit':
-            GitGutterCompareCommit(view, git_handler).run()
+            GitGutterCompareCommit(self.git_handler).run()
         elif action == 'compare_against_branch':
-            GitGutterCompareBranch(view, git_handler).run()
+            GitGutterCompareBranch(self.git_handler).run()
         elif action == 'compare_against_tag':
-            GitGutterCompareTag(view, git_handler).run()
+            GitGutterCompareTag(self.git_handler).run()
         elif action == 'compare_against_head':
-            GitGutterCompareHead(view, git_handler).run()
+            GitGutterCompareHead(self.git_handler).run()
         elif action == 'compare_against_origin':
-            GitGutterCompareOrigin(view, git_handler).run()
+            GitGutterCompareOrigin(self.git_handler).run()
         elif action == 'show_compare':
-            GitGutterShowCompare(view, git_handler).run()
+            GitGutterShowCompare(self.git_handler).run()
         elif action == 'show_diff_popup':
             point = kwargs['point']
             highlight_diff = kwargs['highlight_diff']
             flags = kwargs['flags']
             show_diff_popup(
-                view, point, git_handler, highlight_diff=highlight_diff,
-                flags=flags)
+                point, self.git_handler,
+                highlight_diff=highlight_diff, flags=flags)
         else:
             assert False, 'Unhandled sub command "%s"' % action
 

--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -4,15 +4,12 @@ import sublime
 
 try:
     from .git_gutter_settings import settings
-    from .promise import Promise
 except (ImportError, ValueError):
     from git_gutter_settings import settings
-    from promise import Promise
 
 
 class GitGutterCompareCommit(object):
-    def __init__(self, view, git_handler):
-        self.view = view
+    def __init__(self, git_handler):
         self.git_handler = git_handler
 
     def run(self):
@@ -22,8 +19,6 @@ class GitGutterCompareCommit(object):
         def decode_and_parse_commit_list(result):
             commit_lines = result.splitlines()
             return [r.split('\a', 2) for r in commit_lines]
-        if not self.git_handler.on_disk():
-            return Promise.resolve([])
         return self.git_handler.git_commits().then(decode_and_parse_commit_list)
 
     def item_to_commit(self, item):
@@ -31,7 +26,7 @@ class GitGutterCompareCommit(object):
 
     def _show_quick_panel(self, results):
         if results:
-            self.view.window().show_quick_panel(
+            self.git_handler.view.window().show_quick_panel(
                 results, partial(self._on_select, results))
 
     def _on_select(self, results, selected):
@@ -49,8 +44,6 @@ class GitGutterCompareBranch(GitGutterCompareCommit):
         def decode_and_parse_branch_list(result):
             branch_lines = result.splitlines()
             return [self._parse_result(r) for r in branch_lines]
-        if not self.git_handler.on_disk():
-            return Promise.resolve([])
         return self.git_handler.git_branches().then(
             decode_and_parse_branch_list)
 
@@ -70,8 +63,6 @@ class GitGutterCompareTag(GitGutterCompareCommit):
                 return [self._parse_result(r) for r in tag_lines]
             sublime.message_dialog("No tags found in repository")
             return []
-        if not self.git_handler.on_disk():
-            return Promise.resolve([])
         return self.git_handler.git_tags().then(decode_and_parse_tag_list)
 
     def _parse_result(self, result):

--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -20,7 +20,7 @@ class GitGutterCompareCommit(object):
 
     def commit_list(self):
         def decode_and_parse_commit_list(result):
-            commit_lines = result.decode("utf-8").strip().split('\n')
+            commit_lines = result.splitlines()
             return [r.split('\a', 2) for r in commit_lines]
         if not self.git_handler.on_disk():
             return Promise.resolve([])
@@ -47,7 +47,7 @@ class GitGutterCompareCommit(object):
 class GitGutterCompareBranch(GitGutterCompareCommit):
     def commit_list(self):
         def decode_and_parse_branch_list(result):
-            branch_lines = result.decode("utf-8").strip().split('\n')
+            branch_lines = result.splitlines()
             return [self._parse_result(r) for r in branch_lines]
         if not self.git_handler.on_disk():
             return Promise.resolve([])
@@ -66,7 +66,7 @@ class GitGutterCompareTag(GitGutterCompareCommit):
     def commit_list(self):
         def decode_and_parse_tag_list(results):
             if results:
-                tag_lines = results.decode("utf-8").strip().split('\n')
+                tag_lines = results.splitlines()
                 return [self._parse_result(r) for r in tag_lines]
             sublime.message_dialog("No tags found in repository")
             return []
@@ -97,7 +97,7 @@ class GitGutterCompareOrigin(GitGutterCompareCommit):
             if branch_name:
                 settings.set_compare_against(
                     self.git_handler.git_dir,
-                    'origin/%s' % branch_name.decode("utf-8").strip())
+                    'origin/%s' % branch_name)
                 self.git_handler.clear_git_time()
                 self.view.run_command('git_gutter')  # refresh ui
         self.git_handler.git_current_branch().then(on_branch_name)

--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -21,7 +21,7 @@ class GitGutterCompareCommit(object):
         return self.git_handler.git_commits().then(parse_results)
 
     def item_to_commit(self, item):
-        return item[1].split(' ')[0]
+        return item[0].split(' ')[0]
 
     def _show_quick_panel(self, results):
         if results:
@@ -34,6 +34,22 @@ class GitGutterCompareCommit(object):
         item = results[selected]
         commit = self.item_to_commit(item)
         self.git_handler.set_compare_against(commit)
+
+
+class GitGutterCompareFileCommit(GitGutterCompareCommit):
+    def commit_list(self):
+        """Built a list of quick panel items with all file commits."""
+        def parse_results(results):
+            """Parse git output and create the quick panel items."""
+            if results:
+                # sort splitted lines by author date in reversed order
+                sorted_results = sorted(results.splitlines(), reverse=True)
+                # split each line by \a and strip time stamp from beginning
+                return [r.split('\a')[1:] for r in sorted_results]
+            sublime.message_dialog(
+                'No commits of this file found in repository.')
+            return []
+        return self.git_handler.git_file_commits().then(parse_results)
 
 
 class GitGutterCompareBranch(GitGutterCompareCommit):

--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -390,13 +390,40 @@ class GitGutterHandler(object):
         return Promise.resolve(False)
 
     def git_commits(self):
+        r"""Query all commits.
+
+        The git output will have following format splitted by \a:
+            <hash> <title>
+            <name> <email>
+            <date> (<time> ago)
+        """
         args = [
             settings.git_binary_path,
             '--git-dir=' + self.git_dir,
             '--work-tree=' + self.git_tree,
             'log', '--all',
-            '--pretty=%s\a%h %an <%aE>\a%ad (%ar)',
+            '--pretty=%h %s\a%an <%aE>\a%ad (%ar)',
             '--date=local', '--max-count=9000'
+        ]
+        return GitGutterHandler.run_command(args)
+
+    def git_file_commits(self):
+        r"""Query all commits with changes to the attached file.
+
+        The git output will have following format splitted by \a:
+            <timestamp>
+            <hash> <title>
+            <name> <email>
+            <date> (<time> ago)
+        """
+        args = [
+            settings.git_binary_path,
+            '--git-dir=' + self.git_dir,
+            '--work-tree=' + self.git_tree,
+            'log',
+            '--pretty=%at\a%h %s\a%an <%aE>\a%ad (%ar)',
+            '--date=local', '--max-count=9000',
+            '--', self.git_path
         ]
         return GitGutterHandler.run_command(args)
 

--- a/git_gutter_jump_to_changes.py
+++ b/git_gutter_jump_to_changes.py
@@ -7,8 +7,7 @@ except (ImportError, ValueError):
 
 
 class GitGutterJumpToChanges(object):
-    def __init__(self, view, git_handler):
-        self.view = view
+    def __init__(self, git_handler):
         self.git_handler = git_handler
 
     def lines_to_blocks(self, lines):
@@ -26,10 +25,11 @@ class GitGutterJumpToChanges(object):
         modified = self.lines_to_blocks(modified)
         all_changes = sorted(inserted + modified + deleted)
         if all_changes:
-            row, col = self.view.rowcol(self.view.sel()[0].begin())
+            view = self.git_handler.view
+            row, col = view.rowcol(view.sel()[0].begin())
             current_row = row + 1
             line = jump_func(all_changes, current_row)
-            self.view.run_command("goto_line", {"line": line})
+            view.run_command("goto_line", {"line": line})
 
     def jump_to_next_change(self):
         self.git_handler.diff().then(partial(self.goto_line, self.next_jump))

--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -21,8 +21,9 @@ if _MDPOPUPS_INSTALLED:
 _MD_POPUPS_USE_WRAPPER_CLASS = int(sublime.version()) >= 3119
 
 
-def show_diff_popup(view, point, git_handler, highlight_diff=False, flags=0):
+def show_diff_popup(point, git_handler, highlight_diff=False, flags=0):
     if _MDPOPUPS_INSTALLED and git_handler.in_repo():
+        view = git_handler.view
         line = view.rowcol(point)[0] + 1
         git_handler.diff_line_change(line).then(
             partial(_show_diff_popup_impl, view, point, highlight_diff, flags))

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -24,7 +24,6 @@ class GitGutterSettings:
         self.ignore_whitespace = False
         self.patience_switch = ''
         self.show_in_minimap = False
-        self.show_status = 'none'
         # Name of this package (GitGutter or GitGutter-Edge)
         # stored in settings as kind of environment variable
         path = os.path.realpath(__file__)
@@ -106,13 +105,6 @@ class GitGutterSettings:
         self.show_in_minimap = (
             self._user_settings.get('show_in_minimap') or
             self._settings.get('show_in_minimap'))
-
-        # Show information in status bar
-        self.show_status = (
-            self._user_settings.get('show_status') or
-            self._settings.get('show_status'))
-        if self.show_status != 'all' and self.show_status != 'none':
-            self.show_status = 'default'
 
     def get_compare_against(self, git_dir, view):
         """Return the compare target for a view.

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -115,14 +115,33 @@ class GitGutterSettings:
             self.show_status = 'default'
 
     def get_compare_against(self, git_dir, view):
+        """Return the compare target for a view.
+
+        If interactivly specified a compare target for the view's repository,
+        use it first, then try view's settings, which includes project
+        settings and preferences. Finally try GitGutter.sublime-settings or
+        fall back to HEAD if everything goes wrong to avoid exceptions.
+
+        Arguments:
+            git_dir     - path of the `.git` directory holding the index
+            view        - the view whose settings to query first
+        """
         # Interactively specified compare target overrides settings.
         if git_dir in self._compare_against_mapping:
             return self._compare_against_mapping[git_dir]
-        compare = self.get('compare_against')
-        # Project settings override plugin settings if set.
-        return view.settings().get('git_gutter_compare_against', compare)
+        # Project settings and Preferences override plugin settings if set.
+        compare = view.settings().get('git_gutter_compare_against')
+        if not compare:
+            compare = self.get('compare_against', 'HEAD')
+        return compare
 
     def set_compare_against(self, git_dir, new_compare_against):
+        """Assign a new compare target for current repository.
+
+        Arguments:
+            git_dir             - path of the .git directory holding the index
+            new_compare_against - new branch/tag/commit to cmpare against
+        """
         self._compare_against_mapping[git_dir] = new_compare_against
 
     @property

--- a/git_gutter_show_diff.py
+++ b/git_gutter_show_diff.py
@@ -4,10 +4,8 @@ import sublime
 
 try:
     from .git_gutter_settings import settings
-    from .promise import Promise
 except (ImportError, ValueError):
     from git_gutter_settings import settings
-    from promise import Promise
 
 ST3 = int(sublime.version()) >= 3000
 _ICON_EXT = '.png' if ST3 else ''
@@ -70,21 +68,17 @@ class GitGutterShowDiff(object):
         self._bind_icons('changed', modified)
 
         if settings.show_status != "none":
-            if settings.show_status == 'all':
-                def decode_and_strip(branch_name):
-                    return branch_name.decode("utf-8").strip()
-                branch_promise = self.git_handler.git_current_branch().then(
-                    decode_and_strip)
-            else:
-                branch_promise = Promise.resolve("")
-
             def update_status_ui(branch_name):
                 self._update_status(
                     len(inserted), len(modified), len(deleted),
                     settings.get_compare_against(
                         self.git_handler.git_dir, self.view),
                     branch_name)
-            branch_promise.then(update_status_ui)
+
+            if settings.show_status == 'all':
+                self.git_handler.git_current_branch().then(update_status_ui)
+            else:
+                update_status_ui('')
         else:
             self._update_status(0, 0, 0, "", "")
 

--- a/git_gutter_show_diff.py
+++ b/git_gutter_show_diff.py
@@ -17,12 +17,19 @@ class GitGutterShowDiff(object):
                     'untracked', 'ignored']
 
     def __init__(self, view, git_handler):
+        """Initialize an object instance."""
         self.view = view
         self.git_handler = git_handler
         self.diff_results = None
         self.show_untracked = False
 
     def run(self):
+        """Run diff and update gutter icons and status message."""
+
+        # git_time_reset was called recently, maybe branch has changed
+        # Status message needs an update on this run.
+        if self.git_handler.git_time_cleared():
+            self.diff_results = None
         self.git_handler.diff().then(self._check_ignored_or_untracked)
 
     def _check_ignored_or_untracked(self, contents):
@@ -71,8 +78,7 @@ class GitGutterShowDiff(object):
             def update_status_ui(branch_name):
                 self._update_status(
                     len(inserted), len(modified), len(deleted),
-                    settings.get_compare_against(
-                        self.git_handler.git_dir, self.view),
+                    self.git_handler.format_compare_against(),
                     branch_name)
 
             if settings.show_status == 'all':


### PR DESCRIPTION
I'd like to introduce the following changes to GitGutter. I packed several things into this PR as they all belong together, modify the same parts of code and would otherwise make too much work to merge correctly again as they base on each other.

### 1 Infrastructure
The first commits are some kind of infrastructure changes to ease handling of git output and reduce some cross references of git_gutter modules. They mainly intend to reduce required lines of code. They are the base of the following functional changes and additions.

### 2 Show branch name in compared against status message

I was always confuesed about the Comparing against: ... status messages. It only shows HEAD or a certain commit hash instead of the name of a branch selected as compare target. 

#### Issue

Comparing against branch doesn't actually tell GitGutter to compare against the HEAD of the selected branch but only against the currently latest commit. This has two side effects. The branch name is not displayed in the status bar and if the branch forwards, GitGutter won't see that.

#### Solution

Save the whole `refs/heads/...` or `refs/tags/...` strings instead of commit hashes, if _Compare against branch_ or _Compare against tag_ was called.

### 3 Make the status message somewhat smarter

The status message should show for all files within a git repository no matter if the gutter icons show or not. So user can see, if the file is contained in a git repo and which state (ignored/untracked) it has. Furthermore the statistics message itself should always show the 'Regions' or 'Lines' extension after the first visible _inserted/deleted/modified_ item.

### 4 Compare against specific file commit (Issue #281) 

Add a new function to select all commits sorted by author date, which introduced changes to the file displayed in the active view.