### PR TITLE
Fixup debounce and handle events synchronous.

### DIFF
--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -76,9 +76,6 @@ class GitGutterEvents(EventListener):
         event and content is not yet fully available. So drop the event if
         the view is still loading or marked as scratch.
         """
-        if view.is_scratch() or view.is_loading():
-            return
-
         if self.live_mode() or self.focus_change_mode():
             self.debounce(view, 'activated')
 


### PR DESCRIPTION
## 1 Debounce

1. The `_latest_keypresses` dictionary used to debounce is cleaned up for no longer existing views.
2. Use the `view.id()` as key for debouncing as `file_name()` can be `None` and the calling event does not matter for debouncing at all. If two different events are received quickly after each other, debouncing should work, too.

## 2 Synchronous Events

As the expensive job is already queued asynchronous with the help of a Promise, the only task left for the EventHandler is to debounce and call a command. Both tasks take no time at all and therefore don't need to be asynchronous. This also reduces the delay for events being handled.
