### PR TITLE
Fix Issue #220 and add Side-By-Side settings support

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -30,5 +30,59 @@
     {
         "caption": "GitGutter: Compare Against Tag",
         "command": "git_gutter_compare_tag"
+    },
+    {
+        "caption": "Preferences: GitGutter Settings",
+        "command": "git_gutter_edit_settings",
+        "args": {
+            "base_file": "${packages}/GitGutter/GitGutter.sublime-settings",
+            "default": "// GitGutter Settings - User\n{\n\t$0\n}\n"
+        }
+    },
+    {
+        "caption": "Preferences: GitGutter Settings - Default",
+        "command": "git_gutter_open_file",
+        "args": {"file": "${packages}/GitGutter/GitGutter.sublime-settings"}
+    },
+    {
+        "caption": "Preferences: GitGutter Settings - User",
+        "command": "git_gutter_open_file",
+        "args": {"file": "${packages}/User/GitGutter.sublime-settings"}
+    },
+    {
+        "caption": "Preferences: GitGutter Key Bindings",
+        "command": "git_gutter_edit_settings",
+        "args": {
+            "base_file": "${packages}/GitGutter/Default (${platform}).sublime-keymap",
+            "default": "// GitGutter Key Bindings - User\n{\n\t$0\n}\n"
+        }
+    },
+    {
+        "caption": "Preferences: GitGutter Key Bindings - Default",
+        "command": "git_gutter_open_file",
+        "args": {"file": "${packages}/GitGutter/Default (${platform}).sublime-keymap"}
+    },
+    {
+        "caption": "Preferences: GitGutter Key Bindings - User",
+        "command": "git_gutter_open_file",
+        "args": {"file": "${packages}/User/Default (${platform}).sublime-keymap"}
+    },
+    {
+        "caption": "Preferences: GitGutter Popup Stylesheet",
+        "command": "git_gutter_edit_settings",
+        "args": {
+            "base_file": "${packages}/GitGutter/gitgutter_popup.css",
+            "default": "/* GitGutter Popup Stylesheet - User */\n\n"
+        }
+    },
+    {
+        "caption": "Preferences: GitGutter Popup Stylesheet - Default",
+        "command": "git_gutter_open_file",
+        "args": {"file": "${packages}/GitGutter/gitgutter_popup.css"}
+    },
+    {
+        "caption": "Preferences: GitGutter Popup Stylesheet - User",
+        "command": "git_gutter_open_file",
+        "args": {"file": "${packages}/User/gitgutter_popup.css"}
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -81,74 +81,60 @@
                         "children":
                         [
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/GitGutter/GitGutter.sublime-settings"},
-                                "caption": "Settings – Default"
+                                "caption": "Settings",
+                                "command": "git_gutter_edit_settings",
+                                "args": {
+                                    "base_file": "${packages}/GitGutter/GitGutter.sublime-settings",
+                                    "default": "// GitGutter Settings - User\n{\n\t$0\n}\n"
+                                }
                             },
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/GitGutter.sublime-settings"},
-                                "caption": "Settings – User"
+                                "caption": "Settings - Default",
+                                "command": "git_gutter_open_file",
+                                "args": {"file": "${packages}/GitGutter/GitGutter.sublime-settings"}
+                            },
+                            {
+                                "caption": "Settings - User",
+                                "command": "git_gutter_open_file",
+                                "args": {"file": "${packages}/User/GitGutter.sublime-settings"}
                             },
                             { "caption": "-" },
                             {
-                                "command": "open_file",
+                                "caption": "Key Bindings",
+                                "command": "git_gutter_edit_settings",
                                 "args": {
-                                    "file": "${packages}/GitGutter/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – Default"
+                                    "base_file": "${packages}/GitGutter/Default (${platform}).sublime-keymap",
+                                    "default": "// GitGutter Key Bindings - User\n{\n\t$0\n}\n"
+                                }
                             },
                             {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/GitGutter/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – Default"
+                                "caption": "Key Bindings - Default",
+                                "command": "git_gutter_open_file",
+                                "args": {"file": "${packages}/GitGutter/Default (${platform}).sublime-keymap"}
                             },
                             {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/GitGutter/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – User"
+                                "caption": "Key Bindings - User",
+                                "command": "git_gutter_open_file",
+                                "args": {"file": "${packages}/User/Default (${platform}).sublime-keymap"}
                             },
                             { "caption": "-" },
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/GitGutter/gitgutter_popup.css"},
-                                "caption": "Popup Stylesheet – Default"
+                                "caption": "Popup Stylesheet",
+                                "command": "git_gutter_edit_settings",
+                                "args": {
+                                    "base_file": "${packages}/GitGutter/gitgutter_popup.css",
+                                    "default": "/* GitGutter Popup Stylesheet - User */\n\n"
+                                }
                             },
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/gitgutter_popup.css"},
-                                "caption": "Popup Stylesheet – User"
+                                "caption": "Popup Stylesheet - Default",
+                                "command": "git_gutter_open_file",
+                                "args": {"file": "${packages}/GitGutter/gitgutter_popup.css"}
+                            },
+                            {
+                                "caption": "Popup Stylesheet - User",
+                                "command": "git_gutter_open_file",
+                                "args": {"file": "${packages}/User/gitgutter_popup.css"}
                             }
                         ]
                     }

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -1,12 +1,54 @@
 import os
 import shutil
 import sublime
+from sublime_plugin import ApplicationCommand
 
-ST3 = int(sublime.version()) >= 3000
+STVER = int(sublime.version())
+ST3 = STVER >= 3000
 
 
 def plugin_loaded():
     settings.load_settings()
+
+
+class GitGutterOpenFileCommand(ApplicationCommand):
+    """This is a wrapper class for SublimeText's `open_file` command.
+
+    The task is to hide the command in menu if `edit_settings` is available.
+    """
+
+    def run(self, file):
+        """Expand variables and open the resulting file.
+
+        NOTE: For some unknown reason the `open_file` command doesn't expand
+              ${platform} when called by `run_command`, so it is expanded here.
+        """
+        platform_name = {
+            'osx': 'OSX',
+            'windows': 'Windows',
+            'linux': 'Linux',
+        }[sublime.platform()]
+        file = file.replace('${platform}', platform_name)
+        sublime.run_command('open_file', {'file': file})
+
+    def is_visible(self):
+        """Return True to to show the command in command pallet and menu."""
+        return STVER < 3124
+
+
+class GitGutterEditSettingsCommand(ApplicationCommand):
+    """This is a wrapper class for SublimeText's `open_file` command.
+
+    Hides the command in menu if `edit_settings` is not available.
+    """
+
+    def run(self, **kwargs):
+        """Expand variables and open the resulting file."""
+        sublime.run_command('edit_settings', kwargs)
+
+    def is_visible(self):
+        """Return True to to show the command in command pallet and menu."""
+        return STVER >= 3124
 
 
 class GitGutterSettings:


### PR DESCRIPTION
This commit introduces two ApplicationCommands:

1. `git_gutter_edit_settings` is a wrapper for the `edit_settings` command introduced with Sublime Text 3124 to show default and user settings side-by-side.
2. `git_gutter_open_file` is a wrapper for the `open_file` command in Sublime Text used to open settings files.

Both commands expand the variable ${package} to whatever the real local package name of GitGutter is and makes those commands work even if the package was renamed. By default it expands to 'GitGutter' but works with 'GitGutter-Edge', too. This fixes issue #220, even though @jisaacks doesn't want to support Edge anymore.

The second task of those wrapper commands is to make use of `edit_settings` without breaking backward compatibility for older Sublime Text builts.

The three required `edit_settings` commands are added to the command pallet and main menu. The `open_file` commands make use of ${platform} to make the menu file smaller.