### PR TITLE
Readd dependencies to >=3080 entry

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -7,7 +7,9 @@
         ">=3080": [
             "pygments",
             "python-markdown",
-            "mdpopups"
+            "mdpopups",
+            "python-jinja2",
+            "markupsafe"
         ]
     }
 }


### PR DESCRIPTION
The dependencies should be duplicated.

> The most-specific selectors will be used, and all other ignored. This
> means that some dependencies will be duplicated under a specific
> platform and under *.

https://github.com/wbond/package_control/blob/master/example-dependencies.json