### PR TITLE
Fix: Resolve symlinks on Windows machines correctly (Issue #373)

### DIFF
--- a/modules/path.py
+++ b/modules/path.py
@@ -1,0 +1,74 @@
+import os.path
+
+try:
+    from nt import _getfinalpathname
+    def realpath(path):
+        """Resolve symlinks and return real path to file.
+
+        Note:
+            This is a fix for the issue of os.path.realpath() not to resolve
+            symlinks on Windows as it is an alias to abspath() only.
+            see: http://bugs.python.org/issue9949
+
+        Arguments:
+            path (string): The path to resolve.
+
+        Returns:
+            string: The resolved absolute path.
+        """
+        final_path = _getfinalpathname(path)
+        return final_path.replace('\\\\?\\', '')
+
+except (AttributeError, ImportError):
+    def realpath(path):
+        """Resolve symlinks and return real path to file.
+
+        Arguments:
+            path (string): The path to resolve.
+
+        Returns:
+            string: The resolved absolute path.
+        """
+        return os.path.realpath(path)
+
+
+def is_work_tree(path):
+    """Check if 'path' is a valid git working tree.
+
+    A working tree contains a `.git` directory or file.
+
+    Arguments:
+        path (string): The path to check.
+
+    Returns:
+        bool: True if path contains a '.git'
+    """
+    return path and os.path.exists(os.path.join(path, '.git'))
+
+
+def split_work_tree(file_path):
+    """Split the 'file_path' into working tree and relative path.
+
+    The file_path is converted to a absolute real path and split into
+    the working tree part and relative path part.
+
+    Note:
+        This is a local alternitive to calling the git command:
+
+            git rev-parse --show-toplevel
+
+    Arguments:
+        file_path (string): Absolute path to a file.
+
+    Returns:
+        A tuple of two the elements (working tree, file path).
+    """
+    if file_path:
+        path, name = os.path.split(file_path)
+        # files within '.git' path are not part of a work tree
+        while path and name and name != '.git':
+            if is_work_tree(path):
+                return (path, os.path.relpath(
+                    file_path, path).replace('\\', '/'))
+            path, name = os.path.split(path)
+    return (None, None)


### PR DESCRIPTION
This is a fix for the issue of os.path.realpath() not to resolve symlinks on
Windows as it is an alias to abspath() only.

see: http://bugs.python.org/issue9949

## Note 1

As git_gutter_handler.py and the GitGutterHandler class grows too much,
the related functions for path handling are moved to a seperate module.

## Note 2

With respect to future plans for a modularized plugin structure, the
path functions are put into the folder 'modules'.

This is something maybe worth discussing as modularization in sub directories may have some advantages from my current point of view.

Several packages split their code to small modules contained in subdirectories to not pollute the globals of ST3. This enables export of only the API objects. As a result ST3 would show only a main module upon startup. This would also fix the issue of settings object being loaded several times without the strange `if settings in globals` query.

I am interested in what you think about it.