### PR TITLE
Add release notes for V1.5.0

### DIFF
--- a/release_messages/src/messages/1.5.0.txt
+++ b/release_messages/src/messages/1.5.0.txt
@@ -1,0 +1,47 @@
+Changes since 1.4.0:
+
+  Enhancement:
+   - Avoid creation of temporary files, if view does not show a file from a valid git repository.
+   - Optimize number of git and diff calls.
+   - Determine, whether a view's file really exists on disk.
+   - Make "compare to" functionality work per git directory (Issue #327)
+   - Optimize some encoding/decoding stuff.
+   - Use jinja2 template engine to render status bar messages if library is available.
+   - Read file from git index only, if the compare target has changed.
+   - Event driven tracking of changed compare target replaces polling.
+   - Update the temporary buffer file only, if the view has changed.
+   - Run git diff only if one of the temporary files changed.
+   - Query git for compare commit hash only if not comparing against commit.
+   - Don't call git for diff popup at all.
+   - Refactoring the EventListener to best fit the current structure.
+   - Add some idle time between git calls to reduce lacks on ST2
+
+  Feature:
+   - Add support for custom icon packages (Issue #256)
+   - Add 'Compare against file commit' and enable filtering by commit id (Issue #142, #281)
+   - Add Side-By-Side settings support and show in command pallet
+   - Add support to set marker size in minimap (Issue #263)
+   - Show file status (committed/modified/untracked/ignored) on status bar (Issue #226)
+
+  Fix:
+   - Disable GitGutter, if git binary was not found (Issue #94, #352)
+   - Create only one instance of GitGutterSettings (Issue #334)
+   - error invoking git on Windows systems (Issue #244, #357)
+   - Fix issue with all untracked and ignored files being marked incorrectly (Issue #267, #279, #353).
+   - Show the correct branch or tag name in the 'compare against' status message.
+   - Avoid exception due to missing dependencies. (Issue #366)
+   - Fall back to simple status bar text if jinja2 is not available (Issue #366)
+   - Run all git commands from within working tree (Issue #239, #248, #290)
+   - Follow symlinks correctly to the source file in the working tree (Issue #373).
+   - diff popup doesn't show modifications on first line.
+   - Noticeable flicker/delay in icons when working with files (Issue #340)
+   - Problem with smudge/clean filters (Issue #74)
+   - Use cached git diff result for 'Goto next/prev git difference' command.
+   - Ensure not to start more than one evaluation at a time.
+   - Disable GitGutter for binary files and scratch views. (Issue #189)
+   - GitGutter ignores on_modified() event in ST2, because view visibility check fails. (Issue #349)
+   - Securing git execution. (Issue #348)
+   - Show markers on new, ignored and untracked files only, if show_markers_on_untracked_file is true.
+
+  README:
+   - Refactoring


### PR DESCRIPTION
I generated the changelog based on V1.4.0 with GitSavvy and did some modifications to keep only the commit messages, which seem useful.

The order is defined by the commit dates. Hope this is ok.

Do we want to create a `1.5.0-rc.1` tag? Should it include changelogs and annotation or not?