### PR TITLE
Improve the css readability by directly writing the class

### DIFF
--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -197,10 +197,7 @@ def _show_diff_popup_impl(view, point, line, highlight_diff, flags, diff_info):
         )
         content = button_line
 
-    if _MD_POPUPS_USE_WRAPPER_CLASS:
-        wrapper_class = ".git-gutter"
-    else:
-        wrapper_class = ""
+    wrapper_class = ".git-gutter" if _MD_POPUPS_USE_WRAPPER_CLASS else ""
 
     # load and join popup stylesheets
     css = []
@@ -218,11 +215,15 @@ def _show_diff_popup_impl(view, point, line, highlight_diff, flags, diff_info):
 
     # apply the jinja template
     jinja_kwargs = {
+        "st_version": sublime.version(),
         "wrapper_class": wrapper_class,
         "use_icons": use_icons
     }
     tmpl = jinja2.environment.Template("\n".join(css))
     css = tmpl.render(**jinja_kwargs)
+    # if the ST version does not support the wrapper class, remove it
+    if not _MD_POPUPS_USE_WRAPPER_CLASS:
+        css = css.replace(".git-gutter", "")
 
     # create the popup
     location = view.line(point).a

--- a/gitgutter_popup.css
+++ b/gitgutter_popup.css
@@ -1,21 +1,21 @@
 /*
     Jinja2 css template. Provided values are:
-        - wrapper_class: the surrounding class;
+        - st_version: the version of Sublime Text;
     Copy the values you want to change into your user directory
     and change them there to overwrite the stylesheet.
 */
 
-{{wrapper_class}} .gitgutter-button {
+.git-gutter .gitgutter-button {
     font-size: 1.15rem;
 }
 
 /* Don't underline button links. */
-{{wrapper_class}} .gitgutter-button a {
+.git-gutter .gitgutter-button a {
     text-decoration: none;
 }
 
 /* Size of button, if they are an image. */
-{{wrapper_class}} .gitgutter-button img {
+.git-gutter .gitgutter-button img {
     height: 1.15rem;
     width: 1.15rem;
 }
@@ -25,25 +25,25 @@
     mode of the popup.
 */
 /* Highlight text, that has not changed. */
-{{wrapper_class}} .gitgutter-hi-equal {
+.git-gutter .gitgutter-hi-equal {
 }
 
 /* Highlight text, that has been inserted. */
-{{wrapper_class}} .gitgutter-hi-inserted {
+.git-gutter .gitgutter-hi-inserted {
     color: green;
 }
 
 /* Highlight text, that has been deleted. */
-{{wrapper_class}} .gitgutter-hi-deleted {
+.git-gutter .gitgutter-hi-deleted {
     color: red;
     text-decoration: underline;
 }
 
 /* Highlight text, that has been inserted and substitutes other text. */
-{{wrapper_class}} .gitgutter-hi-changed .gitgutter-hi-inserted {
+.git-gutter .gitgutter-hi-changed .gitgutter-hi-inserted {
 }
 
 /* Highlight text, that has been deleted and is substituted by other text. */
-{{wrapper_class}} .gitgutter-hi-changed .gitgutter-hi-deleted {
+.git-gutter .gitgutter-hi-changed .gitgutter-hi-deleted {
     color: yellow;
 }


### PR DESCRIPTION
This just replaces `{{wrapper_class}}` by the actual class, but keeps backward compat.