### PR TITLE
Do some final code cleaning before release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Sublime Text
+*.sublime-workspace
+*.vcs-cache

--- a/git_gutter.py
+++ b/git_gutter.py
@@ -1,4 +1,4 @@
-from sublime_plugin import TextCommand
+import sublime_plugin
 
 try:
     from .git_gutter_settings import settings
@@ -10,7 +10,7 @@ try:
     from .git_gutter_jump_to_changes import GitGutterJumpToChanges
     from .git_gutter_popup import show_diff_popup
     from .git_gutter_show_diff import GitGutterShowDiff
-except (ImportError, ValueError):
+except ValueError:
     from git_gutter_settings import settings
     from git_gutter_handler import GitGutterHandler
     from git_gutter_compare import (
@@ -22,9 +22,10 @@ except (ImportError, ValueError):
     from git_gutter_show_diff import GitGutterShowDiff
 
 
-class GitGutterCommand(TextCommand):
+class GitGutterCommand(sublime_plugin.TextCommand):
     def __init__(self, *args, **kwargs):
-        TextCommand.__init__(self, *args, **kwargs)
+        """Initialize GitGutterCommand object."""
+        sublime_plugin.TextCommand.__init__(self, *args, **kwargs)
         self.git_handler = GitGutterHandler(self.view)
         self.show_diff_handler = GitGutterShowDiff(self.git_handler)
         # Last enabled state for change detection
@@ -51,12 +52,12 @@ class GitGutterCommand(TextCommand):
         elif view.settings().get("repl"):
             valid = False
         # Don't handle binary files
-        elif view.encoding() in ('Hexadecimal'):
+        elif view.encoding() == 'Hexadecimal':
             valid = False
         else:
             # Validate work tree on certain events only
             validate = any(event in ('load', 'activated', 'post-save')
-                for event in kwargs.get('event_type', []))
+                           for event in kwargs.get('event_type', []))
             # Don't handle files outside a repository
             if not self.git_handler.work_tree(validate):
                 valid = False
@@ -119,7 +120,7 @@ class GitGutterCommand(TextCommand):
             assert False, 'Unhandled sub command "%s"' % action
 
 
-class GitGutterBaseCommand(TextCommand):
+class GitGutterBaseCommand(sublime_plugin.TextCommand):
     def is_enabled(self, **kwargs):
         return self.view.settings().get('git_gutter_enabled', False)
 

--- a/git_gutter_compare.py
+++ b/git_gutter_compare.py
@@ -1,5 +1,4 @@
-from functools import partial
-
+import functools
 import sublime
 
 
@@ -26,7 +25,7 @@ class GitGutterCompareCommit(object):
     def _show_quick_panel(self, results):
         if results:
             self.git_handler.view.window().show_quick_panel(
-                results, partial(self._on_select, results))
+                results, functools.partial(self._on_select, results))
 
     def _on_select(self, results, selected):
         if 0 > selected < len(results):

--- a/git_gutter_events.py
+++ b/git_gutter_events.py
@@ -5,7 +5,7 @@ import sublime_plugin
 
 try:
     from .git_gutter_settings import settings
-except (ImportError, ValueError):
+except ValueError:
     from git_gutter_settings import settings
 
 try:

--- a/git_gutter_jump_to_changes.py
+++ b/git_gutter_jump_to_changes.py
@@ -1,6 +1,6 @@
 try:
     from .git_gutter_settings import settings
-except (ImportError, ValueError):
+except ValueError:
     from git_gutter_settings import settings
 
 

--- a/git_gutter_popup.py
+++ b/git_gutter_popup.py
@@ -3,16 +3,15 @@ import sublime_plugin
 
 try:
     if int(sublime.version()) < 3080:
-        raise Exception("No popup available.")
+        raise ImportError("No popup available.")
 
     import difflib
     import html
-    from functools import partial
+    import jinja2
+    import mdpopups
 
     _MDPOPUPS_INSTALLED = True
-    import mdpopups
-    import jinja2
-except:
+except ImportError:
     _MDPOPUPS_INSTALLED = False
 
 if _MDPOPUPS_INSTALLED:

--- a/git_gutter_settings.py
+++ b/git_gutter_settings.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import sublime
-from sublime_plugin import ApplicationCommand
+import sublime_plugin
 
 STVER = int(sublime.version())
 ST3 = STVER >= 3000
@@ -11,13 +11,14 @@ def plugin_loaded():
     settings.load_settings()
 
 
-class GitGutterOpenFileCommand(ApplicationCommand):
+class GitGutterOpenFileCommand(sublime_plugin.ApplicationCommand):
     """This is a wrapper class for SublimeText's `open_file` command.
 
     The task is to hide the command in menu if `edit_settings` is available.
     """
 
-    def run(self, file):
+    @staticmethod
+    def run(file):
         """Expand variables and open the resulting file.
 
         NOTE: For some unknown reason the `open_file` command doesn't expand
@@ -31,22 +32,25 @@ class GitGutterOpenFileCommand(ApplicationCommand):
         file = file.replace('${platform}', platform_name)
         sublime.run_command('open_file', {'file': file})
 
-    def is_visible(self):
+    @staticmethod
+    def is_visible():
         """Return True to to show the command in command pallet and menu."""
         return STVER < 3124
 
 
-class GitGutterEditSettingsCommand(ApplicationCommand):
+class GitGutterEditSettingsCommand(sublime_plugin.ApplicationCommand):
     """This is a wrapper class for SublimeText's `open_file` command.
 
     Hides the command in menu if `edit_settings` is not available.
     """
 
-    def run(self, **kwargs):
+    @staticmethod
+    def run(**kwargs):
         """Expand variables and open the resulting file."""
         sublime.run_command('edit_settings', kwargs)
 
-    def is_visible(self):
+    @staticmethod
+    def is_visible():
         """Return True to to show the command in command pallet and menu."""
         return STVER >= 3124
 

--- a/git_gutter_show_diff.py
+++ b/git_gutter_show_diff.py
@@ -1,20 +1,18 @@
-import os
-import sublime
-
 try:
     # avoid exceptions if dependency is not yet satisfied
     import jinja2.environment
     _HAVE_JINJA2 = True
-except (ImportError, ValueError):
+except ImportError:
     _HAVE_JINJA2 = False
+
+import sublime
 
 try:
     from .git_gutter_settings import settings
-except (ImportError, ValueError):
+except ValueError:
     from git_gutter_settings import settings
 
-ST3 = int(sublime.version()) >= 3000
-_ICON_EXT = '.png' if ST3 else ''
+_ICON_EXT = '.png' if int(sublime.version()) >= 3000 else ''
 
 
 class GitGutterShowDiff(object):
@@ -168,15 +166,15 @@ class GitGutterShowDiff(object):
         return (
             # deleted regions
             self._deleted_lines_to_regions(
-                first_line, del_lines, lines_regions, protected)
+                first_line, del_lines, lines_regions, protected) +
             # inserted regions
-            + [self._lines_to_regions(
-                first_line, ins_lines, lines_regions, protected)]
+            [self._lines_to_regions(
+                first_line, ins_lines, lines_regions, protected)] +
             # modified regions
-            + [self._lines_to_regions(
-                first_line, mod_lines, lines_regions, protected)]
+            [self._lines_to_regions(
+                first_line, mod_lines, lines_regions, protected)] +
             # untracked / ignored regions
-            + [] + [])
+            [] + [])
 
     def _get_modified_region(self, first_line, last_line):
         """Create a list of all line start points in the modified Region.

--- a/modules/path.py
+++ b/modules/path.py
@@ -2,6 +2,7 @@ import os.path
 
 try:
     from nt import _getfinalpathname
+
     def realpath(path):
         """Resolve symlinks and return real path to file.
 


### PR DESCRIPTION
I checked and fixed some linter errors which I would like to include into the next release. Can you check for any regressions, please?

#### IMPORTS

1. As suggested by google the imports are grouped into

   a) system imports
   b) global imports (ST API)
   c) package imports

   where possible and sorted by name.

2. ImportError is no longer catched from local relative imports as python 2 raises a ValueError only, if relative import fails. ImportError might be something worse, we want to see on ST3.

3. Generally changed all system- & global imports not to import functions or objects where possible. Use simple import <library> instead.

#### DOCSTRINGS

Added/fixed some docstrings to comply with pydocstyle and pylint.

#### STATICMETHODS

Pylint suggested some methods to change to normal functions as they don't access any attribute. So I followed them.

#### GITIGNORE

Added some entries to the .gitignore

_*.vcs-cache_ is created by SublimeLinter
_*.sublime-workspace_ mustn't be included in a commit, too.