### PR TITLE
Fix: Files are randomly marked as modified (Issue #381)

### DIFF
--- a/git_gutter_handler.py
+++ b/git_gutter_handler.py
@@ -271,6 +271,9 @@ class GitGutterHandler(object):
                     # by exactly one file whose content we are interested in.
                     archive = zipfile.ZipFile(BytesIO(output))
                     contents = archive.read(archive.filelist[-1])
+                # Mangle end of lines
+                contents = contents.replace(b'\r\n', b'\n')
+                contents = contents.replace(b'\r', b'\n')
                 # Write the content to file
                 if not self._git_temp_file:
                     self._git_temp_file = self.tmp_file()


### PR DESCRIPTION
### Issue:

With introducing `git archive` command it was considered save to remove the `eol` mangling as correct translations should happen by this command.

This seems not to apply sometimes.

### Solution:

Reintroduce `eol` mangling for the files read from repository.

### Note:

As the temporary view file is created from text, it should be written to disk with `\n` and thus shouldn't need mangling.