### PR TITLE
Skip empty statuses and add commas automatically

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -82,11 +82,11 @@
   //   {{modified}} -- number of modified lines
   "status_bar_text": [
     "In {{repo}} on {{branch}}",
-    "{% if compare not in ('HEAD', branch) %}, Comparing against {{compare}}{% endif %}",
-    ", File is {{state}}",
-    "{% if deleted != 0 %}, {{deleted}}-{% endif %}",
-    "{% if inserted != 0 %}, {{inserted}}+{% endif %}",
-    "{% if modified != 0 %}, {{modified}}≠{% endif %}"
+    "{% if compare not in ('HEAD', branch) %}Comparing against {{compare}}{% endif %}",
+    "File is {{state}}",
+    "{% if deleted != 0 %}{{deleted}}-{% endif %}",
+    "{% if inserted != 0 %}{{inserted}}+{% endif %}",
+    "{% if modified != 0 %}{{modified}}≠{% endif %}"
   ],
 
   // Show GitGutter information in the minimap


### PR DESCRIPTION
This removes the need for commas at the beginning of the `status_bar_text` templates. Commas are now added automatically in between the templates.

Before, if the first template was optional, then the second one would display with a comma at the beginning even though there was nothing before it. It now checks and skips rendered templates if they are an empty string.