### PR TITLE
Fix bug in protected region handling for ignored/untracked files

### DIFF
--- a/git_gutter_show_diff.py
+++ b/git_gutter_show_diff.py
@@ -290,12 +290,12 @@ class GitGutterShowDiff(object):
         chars = view.size()
         region = sublime.Region(start, chars)
         for line in view.substr(region).splitlines():
+            end = start + len(line)
             if start not in protected:
-                end = start + len(line)
                 region = sublime.Region(
                     start, min(end, start + self._minimap_size))
                 regions.append(region)
-                start = end + 1
+            start = end + 1
         self._line_height = view.line_height()
         self._minimap_size = self.git_handler.settings.show_in_minimap
         self._bind_regions(event, regions)


### PR DESCRIPTION
While binding untracked or ignored files, new gitgutter regions would
stop being added after the loop scanning the file detected any protected
region. In effect, this means that gitgutter would only display marks on
lines before the first protected region in untracked/ignored files.