### PR TITLE
1.6.0 release

### DIFF
--- a/release_messages/src/messages/1.6.0.txt
+++ b/release_messages/src/messages/1.6.0.txt
@@ -1,0 +1,10 @@
+1.6.0:
+------
+
+  Fix:
+   - Possible import issue.
+   - Remove git diff command line argument '--indent-heuristic'. (Issue #403)
+   - Typo in GitGutter.sublime-settings
+
+  README:
+   - Fix minimum requirements for diff popup to ST 3080+


### PR DESCRIPTION
The only real issue reported this week was fixed, so I guess we are save to release 1.6.0

This PR includes the source file for the release message with all changes since 1.6.0-rc.1

I leave it up to @jisaacks to cut the release.