### PR TITLE
Diff Popup

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -47,11 +47,6 @@
   //         the differences in the popup
   "diff_popup_default_mode": "default",
 
-  // (ST3 only)
-  // Whether the the diff popup should use icons (true) or
-  // text (false) buttons
-  "diff_popup_use_icon_buttons": true,
-
   // Delay update of gutter icons by the following amount (in milliseconds).
   "debounce_delay": 1000,
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,7 @@ GitGutter handles Package Control's `post_upgrade` event to reload all its submo
 
 The diff popup appears by hovering the mouse over the gutter changes on Sublime Text 3 or can be called from command palette by `GitGutter: Show Diff Popup` or via a key binding.
 
-ⓘ _popups require Sublime Text 3 Build 3080+_
-
-ⓘ _mouse hover feature requires Sublime Text 3 Build 3116+_
+ⓘ requires Sublime Text 3 Build 3119+ and mdpopups 1.9.0+_
 
 ![diff_popup_screenshot](https://cloud.githubusercontent.com/assets/12573621/17908698/ccbecd24-6981-11e6-8f56-edd0faaed9ec.png)
 
@@ -250,7 +248,7 @@ GitGutter evaluates changes every time the file is modified by default. Set `fal
 
 `"enable_hover_diff_popup": true`
 
-ⓘ _requires Sublime Text 3 Build 3116+_
+ⓘ requires Sublime Text 3 Build 3119+ and mdpopups 1.9.0+_
 
 GitGutter shows a diff popup, when hovering over changes in the gutter. Set `false` to disable this popup. You can still open it with a key binding and from the command palette.
 
@@ -259,14 +257,14 @@ GitGutter shows a diff popup, when hovering over changes in the gutter. Set `fal
 
 `"diff_popup_default_mode": "default"`
 
-ⓘ _requires Sublime Text 3 Build 3080+_
+ⓘ requires Sublime Text 3 Build 3119+ and mdpopups 1.9.0+_
 
 The popup displays the previous state of the content under the cursor by `"default"` but can be set to `"diff"` to highlight the differences between the git state and the editor state.
 
 
 #### Diff Popup Appearance
 
-ⓘ _requires Sublime Text 3 Build 3080+_
+ⓘ requires Sublime Text 3 Build 3119+ and mdpopups 1.9.0+_
 
 The popup uses the [mdpopups](https://github.com/facelessuser/sublime-markdown-popups) library and the corresponding settings are global and not only for GitGutter. Syntax highlighting can be set to match the active color scheme by adding `"mdpopups.use_sublime_highlighter": true` to the User settings.
 

--- a/gitgutter_popup.css
+++ b/gitgutter_popup.css
@@ -41,9 +41,26 @@
  **/
 html.dark {
     background-color: color(var(--background) blend(#fff 90%));
+    --diffpopup-ins-bg: color(green blend(black 60%));
+    --diffpopup-ins-fg: color(green blend(white 40%));
+    --diffpopup-del-bg: color(red blend(black 60%));
+    --diffpopup-del-fg: color(red blend(white 40%));
+    --diffpopup-chg-ins-bg: color(#769908 blend(black 95%));
+    --diffpopup-chg-ins-fg: color(#769908 blend(white 20%));
+    --diffpopup-chg-del-bg: color(orangered blend(black 80%));
+    --diffpopup-chg-del-fg: color(orangered blend(white 40%));
 }
+
 html.light {
     background-color: color(var(--background) blend(#000 90%));
+    --diffpopup-ins-bg: color(green blend(white 25%));
+    --diffpopup-ins-fg: color(green blend(black 80%));
+    --diffpopup-del-bg: color(red blend(white 25%));
+    --diffpopup-del-fg: color(red blend(black 80%));
+    --diffpopup-chg-ins-bg: color(#93921b blend(white 20%));
+    --diffpopup-chg-ins-fg: color(#93921b blend(black 85%)); /*#b3ca23*/
+    --diffpopup-chg-del-bg: color(orangered blend(white 20%));
+    --diffpopup-chg-del-fg: color(orangered blend(black 85%));
 }
 
 /* Compatibility rules for correct popup borders with mdpopups 1.x.x */
@@ -125,6 +142,15 @@ div.git-gutter {
 }
 
 /**
+ * TEXT LINE
+ *
+ * Each line is wrapped into <p> tag.
+ **/
+.git-gutter .highlight p {
+    margin: 0;
+}
+
+/**
  * DIFF HIGHLIGHTING
  *
  * The following entries apply to the "highlight difference"
@@ -138,22 +164,24 @@ div.git-gutter {
 
 /* Highlight text, that has been inserted. */
 .git-gutter .hi-ins {
-    color: var(--greenish);
-    text-decoration: underline;
+    color: var(--diffpopup-ins-fg);
+    background-color: var(--diffpopup-ins-bg);
 }
 
 /* Highlight text, that has been deleted. */
 .git-gutter .hi-del {
-    color: var(--redish);
-    text-decoration: underline;
+    color: var(--diffpopup-del-fg);
+    background-color: var(--diffpopup-del-bg);
 }
 
 /* Highlight text, that has been inserted and substitutes other text. */
 .git-gutter .hi-chg-ins {
-    color: var(--yellowish);
+    color: var(--diffpopup-chg-ins-fg);
+    background-color: var(--diffpopup-chg-ins-bg);
 }
 
 /* Highlight text, that has been deleted and is substituted by other text. */
 .git-gutter .hi-chg-del {
-    color: var(--orangish);
+    color: var(--diffpopup-chg-del-fg);
+    background-color: var(--diffpopup-chg-del-bg);
 }

--- a/gitgutter_popup.css
+++ b/gitgutter_popup.css
@@ -157,11 +157,6 @@ div.git-gutter {
  * mode of the popup.
  **/
 
-/* Highlight text, that has not changed. */
-.git-gutter .hi-equal {
-    color: var(--foreground);
-}
-
 /* Highlight text, that has been inserted. */
 .git-gutter .hi-ins {
     color: var(--diffpopup-ins-fg);

--- a/gitgutter_popup.css
+++ b/gitgutter_popup.css
@@ -1,49 +1,159 @@
-/*
-    Jinja2 css template. Provided values are:
-        - st_version: the version of Sublime Text;
+/**********************************************************************
+
+    This is the default stylesheet for GitGutter diff popup.
+
+    It defines additional rules to merge with mdpopups' styleshets.
+
+    NOTE: You can use all jinja2 template variables of mdpopups.
+
+        Examples:
+          var.is_dark
+          var.is_light
+          var.sublime_version       (mdpopups 2.0.0+)
+          var.mdpopups_version      (mdpopups 2.0.0+)
+
+    The popup's HTML structure:
+
+        <div class="mdpopups">
+            <div class="git-gutter">
+                <div class="toolbar">
+                    <a href="revert"><symbol>⟲</symbol></a>
+                    ...
+                    <a href="revert"><text>(revert)</text></a>
+                    ...
+                </div>
+                <div class="highlight">
+                    ... the content goes in here
+                </div>
+            </div>
+        </div>
+
     Copy the values you want to change into your user directory
     and change them there to overwrite the stylesheet.
-*/
 
-.git-gutter .gitgutter-button {
-    font-size: 1.15rem;
+ *********************************************************************/
+
+/**
+ * POPUP BACKGROUND
+ *
+ * Compatibility rules to fix default popup background color
+ * for light and dark color schemes of Sublime Text < 3132.
+ **/
+html.dark {
+    background-color: color(var(--background) blend(#fff 90%));
+}
+html.light {
+    background-color: color(var(--background) blend(#000 90%));
 }
 
-/* Don't underline button links. */
-.git-gutter .gitgutter-button a {
+/* Compatibility rules for correct popup borders with mdpopups 1.x.x */
+div.mdpopups {
+    margin: 0;
+    padding: 0;
+}
+
+/**
+ * POPUP BORDER
+ *
+ * The popup border
+ **/
+div.git-gutter {
+    margin: 0;
+    padding: 1;
+}
+
+/**
+ * TOOLBAR
+ *
+ * The navigation toolbar
+ **/
+.git-gutter div.toolbar {
+    margin: 0;
+    padding: 0.0rem 0.4rem 0.2rem 0.4em;
+}
+
+/**
+ * TEXT BUTTONS
+ *
+ * <text>(revert)</text>
+ *
+ * Text buttons look oversized with normal font size.
+ * This rule is used to fix the font-size.
+ **/
+.git-gutter div.toolbar text {
+    font-size: 0.8rem;
+    margin: 0;
+    padding: 0;
+}
+
+/**
+ * ICON BUTTONS
+ *
+ * <symbol>⟲</symbol>
+ *
+ * Unicode chars are rendered smaller than normal text and sometimes ugly
+ * depending on font-family, so force fonts known to render well.
+ * This rule is used to fix the font-family and font-size.
+ **/
+.git-gutter div.toolbar symbol {
+    font-family: "Roboto Mono", "Segoe UI", monospace;
+    font-size: 1.2rem;
+    margin: 0;
+    padding: 0.0rem 0.1rem 0.0rem 0.1em;
+}
+
+/**
+ * LINKS
+ *
+ * Don't underline links.
+ **/
+.git-gutter a {
     text-decoration: none;
 }
 
-/* Size of button, if they are an image. */
-.git-gutter .gitgutter-button img {
-    height: 1.15rem;
-    width: 1.15rem;
+/**
+ * TEXT VIEW
+ *
+ * Shows the old content or diff.
+ **/
+.git-gutter div.highlight {
+    border-style: none;
+    border-radius: 0;
+    line-height: 1.3rem;
+    margin: 0;
+    padding: 0.7rem 0.7rem 0.6rem 0.7rem;
 }
 
-/*
-    The following entries apply to the "difference highlight"
-    mode of the popup.
-*/
+/**
+ * DIFF HIGHLIGHTING
+ *
+ * The following entries apply to the "highlight difference"
+ * mode of the popup.
+ **/
+
 /* Highlight text, that has not changed. */
-.git-gutter .gitgutter-hi-equal {
+.git-gutter .hi-equal {
+    color: var(--foreground);
 }
 
 /* Highlight text, that has been inserted. */
-.git-gutter .gitgutter-hi-inserted {
-    color: green;
+.git-gutter .hi-ins {
+    color: var(--greenish);
+    text-decoration: underline;
 }
 
 /* Highlight text, that has been deleted. */
-.git-gutter .gitgutter-hi-deleted {
-    color: red;
+.git-gutter .hi-del {
+    color: var(--redish);
     text-decoration: underline;
 }
 
 /* Highlight text, that has been inserted and substitutes other text. */
-.git-gutter .gitgutter-hi-changed .gitgutter-hi-inserted {
+.git-gutter .hi-chg-ins {
+    color: var(--yellowish);
 }
 
 /* Highlight text, that has been deleted and is substituted by other text. */
-.git-gutter .gitgutter-hi-changed .gitgutter-hi-deleted {
-    color: yellow;
+.git-gutter .hi-chg-del {
+    color: var(--orangish);
 }

--- a/gitgutter_popup.css
+++ b/gitgutter_popup.css
@@ -90,20 +90,6 @@ div.git-gutter {
 }
 
 /**
- * TEXT BUTTONS
- *
- * <text>(revert)</text>
- *
- * Text buttons look oversized with normal font size.
- * This rule is used to fix the font-size.
- **/
-.git-gutter div.toolbar text {
-    font-size: 0.8rem;
-    margin: 0;
-    padding: 0;
-}
-
-/**
  * ICON BUTTONS
  *
  * <symbol>⟲</symbol>

--- a/modules/popup.py
+++ b/modules/popup.py
@@ -126,33 +126,26 @@ def _show_diff_popup_impl(
             show_new_popup()
 
     # write the symbols/text for each button
-    use_icons = settings.get("diff_popup_use_icon_buttons")
+    use_icons = settings.get('diff_popup_use_icon_buttons')
     # the buttons as a map from the href to the caption/icon
     button_descriptions = {
-        "hide": chr(0x00D7) if use_icons else "(close)",
-        "copy": chr(0x2398) if use_icons else "(copy)",
-        "revert": chr(0x27F2) if use_icons else "(revert)",
-        "disable_hl_diff": chr(0x2249) if use_icons else "(diff)",
-        "enable_hl_diff": chr(0x2248) if use_icons else "(diff)",
-        "first_change": chr(0x2912) if use_icons else "(first)",
-        "prev_change": chr(0x2191) if use_icons else "(previous)",
-        "next_change": chr(0x2193) if use_icons else "(next)"
+        'hide': '×' if use_icons else '(close)',
+        'copy': '⎘' if use_icons else '(copy)',
+        'revert': '⟲' if use_icons else '(revert)',
+        'disable_hl_diff': '≉' if use_icons else '(diff)',
+        'enable_hl_diff': '≈' if use_icons else '(diff)',
+        'first_change': '⤒' if use_icons else '(first)',
+        'prev_change': '↑' if use_icons else '(previous)',
+        'next_change': '↓' if use_icons else '(next)'
     }
-
-    def is_button_enabled(k):
-        if k in ["first_change", "next_change", "prev_change"]:
-            return meta.get(k, start) != start
-        return True
+    button_fmt = '<span class="gitgutter-button"><a href="{1}">{0}</a></span>'
+    button_disabled_fmt = '<span class="gitgutter-button">{0}</span>'
     buttons = {}
-    for k, v in button_descriptions.items():
-        if is_button_enabled(k):
-            button = '<a href={1}>{0}</a>'.format(v, k)
+    for key, value in button_descriptions.items():
+        if not key.endswith('_change') or meta.get(key, start) != start:
+            buttons[key] = button_fmt.format(value, key)
         else:
-            button = v
-        buttons[k] = (
-            '<span class="gitgutter-button">{0}</span>'
-            .format(button)
-        )
+            buttons[key] = button_disabled_fmt.format(value)
 
     if highlight_diff:
         # (*) show a highlighted diff of the merged git and editor content

--- a/modules/popup.py
+++ b/modules/popup.py
@@ -4,7 +4,7 @@ import sublime_plugin
 
 try:
     if int(sublime.version()) < 3080:
-        raise ImportError("No popup available.")
+        raise ImportError('No popup available.')
 
     import difflib
     import html
@@ -32,8 +32,8 @@ def show_diff_popup(git_gutter, **kwargs):
     # validate highlighting argument
     highlight_diff = kwargs['highlight_diff']
     if highlight_diff is None:
-        mode = git_gutter.settings.get("diff_popup_default_mode", "")
-        highlight_diff = mode == "diff"
+        mode = git_gutter.settings.get('diff_popup_default_mode', '')
+        highlight_diff = mode == 'diff'
     # get line number from text point
     line = git_gutter.view.rowcol(kwargs['point'])[0] + 1
 
@@ -55,10 +55,10 @@ def _show_diff_popup_impl(
     is_added = not is_removed and not is_modified
 
     def navigate(href):
-        if href == "hide":
+        if href == 'hide':
             view.hide_popup()
-        elif href == "revert":
-            new_text = "\n".join(deleted_lines)
+        elif href == 'revert':
+            new_text = '\n'.join(deleted_lines)
             # (removed) if there is no text to remove, set the
             # region to the end of the line, where the hunk starts
             # and add a new line to the start of the text
@@ -67,13 +67,13 @@ def _show_diff_popup_impl(
                     # set the start and the end to the end of the start line
                     start_point = end_point = view.text_point(start, 0) - 1
                     # add a leading newline before inserting the text
-                    new_text = "\n" + new_text
+                    new_text = '\n' + new_text
                 else:
                     # (special handling for deleted at the start of the file)
                     # if we are before the start we need to set the start
                     # to 0 and add the newline behind the text
                     start_point = end_point = 0
-                    new_text = new_text + "\n"
+                    new_text = new_text + '\n'
             # (modified/added)
             # set the start point to the start of the hunk
             # and the end point to the end of the hunk
@@ -86,28 +86,28 @@ def _show_diff_popup_impl(
                 if is_modified and end_point != view.size():
                     end_point -= 1
             replace_param = {
-                "a": start_point,
-                "b": end_point,
-                "text": new_text
+                'a': start_point,
+                'b': end_point,
+                'text': new_text
             }
-            view.run_command("git_gutter_replace_text", replace_param)
+            view.run_command('git_gutter_replace_text', replace_param)
             # hide the popup and update the gutter
             view.hide_popup()
-            view.run_command("git_gutter")
-        elif href in ("disable_hl_diff", "enable_hl_diff"):
+            view.run_command('git_gutter')
+        elif href in ('disable_hl_diff', 'enable_hl_diff'):
             do_diff = {
-                "disable_hl_diff": False,
-                "enable_hl_diff": True
+                'disable_hl_diff': False,
+                'enable_hl_diff': True
             }.get(href)
             # show a diff popup with the same diff info
             _show_diff_popup_impl(
                 view, settings, line, highlight_diff=do_diff, flags=0,
                 diff_info=diff_info)
-        elif href == "copy":
-            sublime.set_clipboard("\n".join(deleted_lines))
+        elif href == 'copy':
+            sublime.set_clipboard('\n'.join(deleted_lines))
             copy_message = "  ".join(l.strip() for l in deleted_lines)
-            sublime.status_message("Copied: " + copy_message)
-        elif href in ("first_change", "next_change", "prev_change"):
+            sublime.status_message('Copied: ' + copy_message)
+        elif href in ('first_change', 'next_change', 'prev_change'):
             next_line = meta.get(href, line)
             pt = view.text_point(next_line - 1, 0)
 
@@ -149,7 +149,7 @@ def _show_diff_popup_impl(
 
     if highlight_diff:
         # (*) show a highlighted diff of the merged git and editor content
-        new_lines = meta["added_lines"]
+        new_lines = meta['added_lines']
         tab_width = view.settings().get('tab_width', 4)
         min_indent = _get_min_indent(deleted_lines + new_lines, tab_width)
         content = (
@@ -189,33 +189,33 @@ def _show_diff_popup_impl(
             .format(**buttons)
         )
 
-    wrapper_class = ".git-gutter" if _MD_POPUPS_USE_WRAPPER_CLASS else ""
+    wrapper_class = '.git-gutter' if _MD_POPUPS_USE_WRAPPER_CLASS else ''
 
     # load and join popup stylesheets
     css = []
     theme_paths = (
-        "Packages/GitGutter",
+        'Packages/GitGutter',
         settings.theme_path,
-        "Packages/User"
+        'Packages/User'
     )
     for path in theme_paths:
         try:
-            resource_name = path + "/gitgutter_popup.css"
+            resource_name = path + '/gitgutter_popup.css'
             css.append(sublime.load_resource(resource_name))
         except IOError:
             pass
 
     # apply the jinja template
     jinja_kwargs = {
-        "st_version": sublime.version(),
-        "wrapper_class": wrapper_class,
-        "use_icons": use_icons
+        'st_version': sublime.version(),
+        'wrapper_class': wrapper_class,
+        'use_icons': use_icons
     }
-    tmpl = jinja2.environment.Template("\n".join(css))
+    tmpl = jinja2.environment.Template('\n'.join(css))
     css = tmpl.render(**jinja_kwargs)
     # if the ST version does not support the wrapper class, remove it
     if not _MD_POPUPS_USE_WRAPPER_CLASS:
-        css = css.replace(".git-gutter", "")
+        css = css.replace('.git-gutter', '')
 
     # create the popup
     location = view.text_point(line - 1, 0)
@@ -269,19 +269,19 @@ def _highlight_diff(old_content, new_content):
     sb = ['<div class="highlight">', '<pre>']
     for op in seq_matcher.get_opcodes():
         op_type, git_start, git_end, edit_start, edit_end = op
-        if op_type == "equal":
+        if op_type == 'equal':
             sb.append(tag_eq)
             sb.append(_to_html(old_content[git_start:git_end]))
             sb.append(tag_close)
-        elif op_type == "delete":
+        elif op_type == 'delete':
             sb.append(tag_del)
             sb.append(_to_html(old_content[git_start:git_end]))
             sb.append(tag_close)
-        elif op_type == "insert":
+        elif op_type == 'insert':
             sb.append(tag_ins)
             sb.append(_to_html(new_content[edit_start:edit_end]))
             sb.append(tag_close)
-        elif op_type == "replace":
+        elif op_type == 'replace':
             sb.append(tag_modified_ins)
             sb.append(_to_html(new_content[edit_start:edit_end]))
             sb.append(tag_close)
@@ -289,15 +289,15 @@ def _highlight_diff(old_content, new_content):
             sb.append(_to_html(old_content[git_start:git_end]))
             sb.append(tag_close)
     sb.extend(['</pre>', '</div>'])
-    return "".join(sb)
+    return ''.join(sb)
 
 
 def _to_html(s):
     return (
         html.escape(s, quote=False)
-        .replace("\n", "<br>")
-        .replace(" ", "&nbsp;")
-        .replace("\u00A0", "&nbsp;")
+        .replace('\n', '<br>')
+        .replace(' ', '&nbsp;')
+        .replace('\u00A0', '&nbsp;')
     )
 
 

--- a/modules/popup.py
+++ b/modules/popup.py
@@ -94,7 +94,7 @@ def _show_diff_popup_impl(
             # hide the popup and update the gutter
             view.hide_popup()
             view.run_command("git_gutter")
-        elif href in ["disable_hl_diff", "enable_hl_diff"]:
+        elif href in ("disable_hl_diff", "enable_hl_diff"):
             do_diff = {
                 "disable_hl_diff": False,
                 "enable_hl_diff": True
@@ -107,7 +107,7 @@ def _show_diff_popup_impl(
             sublime.set_clipboard("\n".join(deleted_lines))
             copy_message = "  ".join(l.strip() for l in deleted_lines)
             sublime.status_message("Copied: " + copy_message)
-        elif href in ["next_change", "prev_change", "first_change"]:
+        elif href in ("first_change", "next_change", "prev_change"):
             next_line = meta.get(href, line)
             pt = view.text_point(next_line - 1, 0)
 
@@ -127,7 +127,6 @@ def _show_diff_popup_impl(
 
     # write the symbols/text for each button
     use_icons = settings.get("diff_popup_use_icon_buttons")
-
     # the buttons as a map from the href to the caption/icon
     button_descriptions = {
         "hide": chr(0x00D7) if use_icons else "(close)",
@@ -160,20 +159,14 @@ def _show_diff_popup_impl(
         new_lines = meta["added_lines"]
         tab_width = view.settings().get('tab_width', 4)
         min_indent = _get_min_indent(deleted_lines + new_lines, tab_width)
-        old_content = '\n'.join(line[min_indent:] for line in deleted_lines)
-        new_content = '\n'.join(line[min_indent:] for line in new_lines)
-        source_html = _highlight_diff(old_content, new_content)
-        button_line = (
+        content = (
             '{hide} '
             '{first_change} {prev_change} {next_change} '
             '{disable_hl_diff} {revert}'
             .format(**buttons)
-        )
-        content = (
-            '{button_line}'
-            '{source_html}'
-            .format(**locals())
-        )
+        ) + _highlight_diff(
+            '\n'.join(line[min_indent:] for line in deleted_lines),
+            '\n'.join(line[min_indent:] for line in new_lines))
 
     elif not is_added:
         # (modified/removed) show content from git database
@@ -185,30 +178,23 @@ def _show_diff_popup_impl(
         # (this has been added to mdpopups in version 1.11.0)
         if mdpopups.version() < (1, 11, 0):
             source_content = source_content.replace(' ', '\u00A0')
-        source_html = mdpopups.syntax_highlight(
-            view, source_content, language=lang)
-        button_line = (
+        content = (
             '{hide} '
             '{first_change} {prev_change} {next_change} '
             '{enable_hl_diff} {copy} {revert}'
             .format(**buttons)
-        )
-        content = (
-            '{button_line}'
-            '{source_html}'
-            .format(**locals())
-        )
+        ) + mdpopups.syntax_highlight(
+            view, source_content, language=lang)
 
     else:
         # (added) only show the button line without the copy button
         # (there is nothing to show or copy)
-        button_line = (
+        content = (
             '{hide} '
             '{first_change} {prev_change} {next_change} '
             '{enable_hl_diff} {revert}'
             .format(**buttons)
         )
-        content = button_line
 
     wrapper_class = ".git-gutter" if _MD_POPUPS_USE_WRAPPER_CLASS else ""
 

--- a/modules/popup/__init__.py
+++ b/modules/popup/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""Diff Popup Module initialization.
+
+Check dependencies and enable/disable diff popup.
+Declare public API functions.
+"""
+try:
+    # mdpopups needs 3119+ for wrapper_class, which diff popup relies on
+    import sublime
+    if int(sublime.version()) < 3119:
+        raise ImportError('Sublime Text 3119+ required.')
+
+    # mdpopups 1.9.0+ is required because of wrapper_class and templates
+    import mdpopups
+    if mdpopups.version() < (1, 9, 0):
+        raise ImportError('mdpopups 1.9.0+ required.')
+
+    # public Sublime Text Commands
+    from .commands import (
+        GitGutterDiffPopupCommand, GitGutterReplaceTextCommand)
+    # public function
+    from .factory import show_diff_popup
+except ImportError:
+    # Some dummy interface objects to avoid import errors
+    GitGutterDiffPopupCommand = None
+    GitGutterReplaceTextCommand = None
+    show_diff_popup = None

--- a/modules/popup/commands.py
+++ b/modules/popup/commands.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""Sublime Text Command Objects
+
+All command objects required by diff popup are defined here.
+"""
+import sublime
+import sublime_plugin
+
+
+class GitGutterReplaceTextCommand(sublime_plugin.TextCommand):
+    """The git_gutter_replace_text command implementation."""
+
+    def run(self, edit, start, end, text):
+        """Replace the content of a region with new text.
+
+        Arguments:
+            edit (Edit):
+                The edit object to identify this operation.
+            start (int):
+                The beginning of the Region to replace.
+            end (int):
+                The end of the Region to replace.
+            text (string):
+                The new text to replace the content of the Region with.
+        """
+        region = sublime.Region(start, end)
+        self.view.replace(edit, region, text)
+
+
+class GitGutterDiffPopupCommand(sublime_plugin.TextCommand):
+    """The git_gutter_diff_popup command implemention."""
+
+    def is_enabled(self):
+        """Check whether diff popup is enabled for the view."""
+        return self.view.settings().get('git_gutter_is_enabled', False)
+
+    def run(self, edit, point=None, highlight_diff=None, flags=0):
+        """Run git_gutter(show_diff_popup, ...) command.
+
+        Arguments:
+            edit (Edit):
+                The edit object to identify this operation (unused).
+            point (int):
+                The text position to show the diff popup for.
+            highlight_diff (string or bool):
+                The desired initial state of dispayed popup content.
+                "default": show old state of the selected hunk
+                "diff": show diff between current and old state
+            flags (int):
+                One of Sublime Text's popup flags.
+        """
+        self.view.run_command('git_gutter', {
+            'action': 'show_diff_popup', 'point': point,
+            'highlight_diff': highlight_diff, 'flags': flags})

--- a/modules/popup/differ.py
+++ b/modules/popup/differ.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""Differ module.
+
+This module is inspired by difflib.Differ which creates human readable diff
+output. Instead of text it outputs html which can be displayed by diff popup
+well.
+"""
+import difflib
+import html
+
+
+def highlight_diff(old_lines, new_lines):
+    """Generate the html string with highlighted diff."""
+    return ''.join(_highlight_diff(old_lines, new_lines))
+
+
+def _highlight_diff(a, b):
+    # begin of mdpopups code view
+    yield '<div class="highlight">'
+    cruncher = difflib.SequenceMatcher(None, a, b, False)
+    for tag, alo, ahi, blo, bhi in cruncher.get_opcodes():
+        if tag == 'replace':
+            g = _fancy_replace(a, alo, ahi, b, blo, bhi)
+        elif tag == 'delete':
+            g = _dump_lines('del', a, alo, ahi)
+        elif tag == 'insert':
+            g = _dump_lines('ins', b, blo, bhi)
+        elif tag == 'equal':
+            g = _dump_lines(None, a, alo, ahi)
+        else:
+            raise ValueError('unknown tag {0}'.format(tag))
+        yield from g
+    # end of mdpopups code view
+    yield '</div>'
+
+
+def _plain_replace(a, alo, ahi, b, blo, bhi):
+    assert alo < ahi and blo < bhi
+    # dump the shorter block first -- reduces the burden on short-term
+    # memory if the blocks are of very different sizes
+    if bhi - blo < ahi - alo:
+        first = _dump_lines('chg-ins', b, blo, bhi)
+        second = _dump_lines('chg-del', a, alo, ahi)
+    else:
+        first = _dump_lines('chg-del', a, alo, ahi)
+        second = _dump_lines('chg-ins', b, blo, bhi)
+
+    for g in first, second:
+        yield from g
+
+
+def _fancy_replace(a, alo, ahi, b, blo, bhi):
+    """Generate comparison results for a same-tagged range."""
+
+    # don't synch up unless the lines have a similarity score of at
+    # least cutoff; best_ratio tracks the best score seen so far
+    best_ratio, cutoff = 0.54, 0.55
+    cruncher = difflib.SequenceMatcher()
+    eqi, eqj = None, None   # 1st indices of equal lines (if any)
+
+    # search for the pair that matches best without being identical
+    # (identical lines must be junk lines, & we don't want to synch up
+    # on junk -- unless we have to)
+    for j in range(blo, bhi):
+        bj = b[j]
+        cruncher.set_seq2(bj)
+        for i in range(alo, ahi):
+            ai = a[i]
+            if ai == bj:
+                if eqi is None:
+                    eqi, eqj = i, j
+                continue
+            cruncher.set_seq1(ai)
+            # computing similarity is expensive, so use the quick
+            # upper bounds first -- have seen this speed up messy
+            # compares by a factor of 3.
+            # note that ratio() is only expensive to compute the first
+            # time it's called on a sequence pair; the expensive part
+            # of the computation is cached by cruncher
+            if cruncher.real_quick_ratio() > best_ratio and \
+                    cruncher.quick_ratio() > best_ratio and \
+                    cruncher.ratio() > best_ratio:
+                best_ratio, best_i, best_j = cruncher.ratio(), i, j
+    if best_ratio < cutoff:
+        # no non-identical "pretty close" pair
+        if eqi is None:
+            # no identical pair either -- treat it as a straight replace
+            yield from _plain_replace(a, alo, ahi, b, blo, bhi)
+            return
+        # no close pair, but an identical pair -- synch up on that
+        best_i, best_j, best_ratio = eqi, eqj, 1.0
+    else:
+        # there's a close pair, so forget the identical pair (if any)
+        eqi = None
+
+    # a[best_i] very similar to b[best_j]; eqi is None if they're not
+    # identical
+
+    # pump out diffs from before the synch point
+    yield from _fancy_helper(a, alo, best_i, b, blo, best_j)
+
+    # pump out the synch point
+    yield '<p>'
+    if eqi is None:
+        aelt, belt = a[best_i], b[best_j]
+        cruncher.set_seqs(aelt, belt)
+        for tag, ai1, ai2, bj1, bj2 in cruncher.get_opcodes():
+            if tag == 'replace':
+                yield from _dump_chunk('chg-del', aelt[ai1:ai2])
+                yield from _dump_chunk('chg-ins', belt[bj1:bj2])
+            elif tag == 'delete':
+                yield from _dump_chunk('del', aelt[ai1:ai2])
+            elif tag == 'insert':
+                yield from _dump_chunk('ins', belt[bj1:bj2])
+            elif tag == 'equal':
+                yield from _dump_chunk(None, belt[bj1:bj2])
+            else:
+                raise ValueError('unknown tag {0}'.format(tag))
+    else:
+        yield from _dump_chunk(None, a[best_i])
+    yield '</p>'
+
+    # pump out diffs from after the synch point
+    yield from _fancy_helper(a, best_i+1, ahi, b, best_j+1, bhi)
+
+
+def _fancy_helper(a, alo, ahi, b, blo, bhi):
+    if alo < ahi:
+        if blo < bhi:
+            g = _fancy_replace(a, alo, ahi, b, blo, bhi)
+        else:
+            g = _dump_lines('del', a, alo, ahi)
+    elif blo < bhi:
+        g = _dump_lines('ins', b, blo, bhi)
+    else:
+        g = []
+
+    yield from g
+
+
+def _dump_lines(tag, x, lo, hi):
+    """Generate comparison results for a same-tagged range."""
+    for l in x[lo:hi]:
+        yield from _dump_line(tag, l)
+
+
+def _dump_line(tag, x):
+    """Generate comparison results for a same-tagged range."""
+    yield '<p>'
+    yield from _dump_chunk(tag, x)
+    yield '<p>'
+
+
+def _dump_chunk(tag, x):
+    """Generate comparison results for a same-tagged range."""
+    if tag:
+        yield ''.join(('<span class="hi-', tag, '">'))
+    yield from _to_html(x)
+    if tag:
+        yield '</span>'
+
+
+def _to_html(text):
+    text = html.escape(text, quote=False)
+    yield text.replace('  ', '&nbsp;&nbsp;') if text else '↵'

--- a/modules/popup/factory.py
+++ b/modules/popup/factory.py
@@ -141,8 +141,7 @@ def _show_diff_popup_impl(git_gutter, line, highlight_diff, flags, diff_info):
             show_new_popup()
 
     # write the symbols/text for each button
-    use_icons = bool(git_gutter.settings.get('diff_popup_use_icon_buttons'))
-    buttons = _built_toolbar_buttons(start, meta, use_icons)
+    buttons = _built_toolbar_buttons(start, meta)
     location = view.text_point(line - 1, 0)
     # code wrapping is supported by mdpopups 2.0.0 or higher
     code_wrap = _MDPOPUPS_HAVE_CODE_WRAP and view.settings().get('word_wrap')
@@ -226,7 +225,7 @@ def _show_diff_popup_impl(git_gutter, line, highlight_diff, flags, diff_info):
         on_navigate=navigate, **popup_kwargs)
 
 
-def _built_toolbar_buttons(start, meta, use_icons):
+def _built_toolbar_buttons(start, meta):
     """Built the toolbar buttons with icon/text as link/label.
 
     Each toolbar button needs to be rendered using the unicode icon character
@@ -238,8 +237,6 @@ def _built_toolbar_buttons(start, meta, use_icons):
             First line of the current hunk.
         meta (dict):
             The dictionay containing additional hunk information.
-        use_icons (bool):
-            If True to use unicode buttons  or text otherwise.
 
     Returns:
         dict: The dictionay with all buttons where `key` is used as `href`
@@ -251,25 +248,25 @@ def _built_toolbar_buttons(start, meta, use_icons):
             inactive text button: <text>(revert)</text>
     """
     # The format to render disabled/enabled buttons
-    button_format = ('<{0}>{1}</{0}>', '<a href="{2}"><{0}>{1}</{0}></a>')
-    # The tag to use for each button
-    button_tag = ('text', 'symbol')
+    button_format = (
+        '<symbol>{0}</symbol>',
+        '<a href="{1}"><symbol>{0}</symbol></a>'
+    )
     # The buttons as a map from the href to the caption/icon
     button_caption = {
-        'hide': ('(close)', '×'),
-        'copy': ('(copy)', '⎘'),
-        'revert': ('(revert)', '⟲'),
-        'disable_hl_diff': ('(diff)', '≉'),
-        'enable_hl_diff': ('(diff)', '≈'),
-        'first_change': ('(first)', '⤒'),
-        'prev_change': ('(prev)', '↑'),
-        'next_change': ('(next)', '↓')
+        'hide': '×',
+        'copy': '⎘',
+        'revert': '⟲',
+        'disable_hl_diff': '≉',
+        'enable_hl_diff': '≈',
+        'first_change':  '⤒',
+        'prev_change': '↑',
+        'next_change': '↓'
     }
     return {
         key: button_format[
             not key.endswith('_change') or meta.get(key, start) != start
-        ].format(button_tag[use_icons], value[use_icons], key)
-        for key, value in button_caption.items()
+        ].format(value, key) for key, value in button_caption.items()
     }
 
 


### PR DESCRIPTION
I did a little work on diff popup module to hopefully enhance user experience with it.

### Changes

1. Prepare to keep compatible with upcoming _mdpopups 2.0.0_
2. Add support to display wrapped content/diff (requires _mdpopups 2.0.0_)
3. Remove jinja2 template handling of CSS files as it is done by _mdpopups_ already
4. Optical enhancements of the popup itself
   a) fix border width
   b) adapt colors to color scheme
   c) improve visibility on light color schemes
   d) add some spacing around the navigation buttons
   e) navigation buttons try to use fonts which are known to render the symbols well
   f) use background colors to highlight diffs and distinguish replacements/inserts/deletions 
5. Avoid flickering if highlighting diff is enabled/disabled
6. Use the algorithm of difflib.Differ to create the highlighted diff as it produces better diffs in most cases

### Notes

1. All these changes made heavy changes to the _gitgutter_popup.css_ necessary, so users might update their local definitions if used. 
2. Diff Popup requires Sublime Text 3119+ and mdpopups 1.9.0+ needed for wrapper classes and CSS variable support.
3. _mdpopups 2.0.0_ will require Sublime Text 3124
4. TODO: Update README

### Internals
1. Some changes to adapt code style of the other modules
2. Split module into several parts to keep file sizes low.
