### PR TITLE
Enhancement: Add support for git diff --histogram algorithm (Issue #422)

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -50,6 +50,14 @@
   // Delay update of gutter icons by the following amount (in milliseconds).
   "debounce_delay": 1000,
 
+  // The algorithm used by git diff to determine the differences.
+  // "default": let git decide (don't pass an algorithm)
+  // "minimal": use minimal diff algorithm
+  // "patience": use patience diff algorithm
+  //             see: http://bramcohen.livejournal.com/73318.html
+  // "histogram": use histogram diff algorithm
+  "diff_algorithm": "patience",
+
   // Determines whether GitGutter ignores whitespace in modified files.
   // Set "none" to ensure whitespace is considered in the diff
   // Set "eol" to only ignore whitespace at the end of lines
@@ -59,11 +67,6 @@
 
   // Add a special marker on untracked files
   "show_markers_on_untracked_file": true,
-
-  // Add --patience switch to git diff command. See
-  // http://bramcohen.livejournal.com/73318.html for
-  // an example of why you might need this.
-  "patience": true,
 
   // Determines whether GitGutter shows status information in the status bar.
   // Set false to disable status information.

--- a/README.md
+++ b/README.md
@@ -322,6 +322,22 @@ It is valid to use environment variables in the setting value, and they will be 
 In a POSIX environment you can run `which git` to find the path to git if it is in your path.  On Windows, you can use `where git` to do the equivalent.
 
 
+#### Diff Algorithm
+
+`"diff_algorithm": "patience"`
+
+GitGutter uses the "patience" diff algorithm by default. Set`diff_algorithm` to one of the follwoing values to change this behavior.
+
+value       | description
+------------|-----------------------------------------------
+"default"   | The basic greedy diff algorithm. Currently, this is the default.
+"minimal"   | Spend extra time to make sure the smallest possible diff is produced.
+"patience"  | Use "patience diff" algorithm when generating patches.
+"histogram" | This algorithm extends the patience algorithm to "support low-occurrence common elements".
+
+👉 The value determines which command line argument to pass to `git diff`.
+
+
 #### Ignore Whitespace
 
 `"ignore_whitespace": "none"`

--- a/modules/handler.py
+++ b/modules/handler.py
@@ -404,7 +404,7 @@ class GitGutterHandler(object):
             self.settings.git_binary,
             'diff', '-U0', '--no-color', '--no-index',
             self.settings.ignore_whitespace,
-            self.settings.patience_switch,
+            self.settings.diff_algorithm,
             self._git_temp_file,
             self._view_temp_file,
         )))

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -78,7 +78,11 @@ class ViewSettings(object):
         'all': '-w'
     }
     # A map to translate between settings and git arguments
-    _PATIENCE_SWITCH = (None, '--patience')
+    _DIFF_ALGORITHM = {
+        'minimal': '--minimal',
+        'patience': '--patience',
+        'histogram': '--histogram'
+    }
 
     def __init__(self, view):
         """Initialize a ViewSettings object.
@@ -165,9 +169,15 @@ class ViewSettings(object):
             return None
 
     @property
-    def patience_switch(self):
-        """The git patience command line argument from settings."""
-        return self._PATIENCE_SWITCH[bool(self.get('patience'))]
+    def diff_algorithm(self):
+        """The git diff algorithm command line argument from settings.
+
+        Returns:
+            string:
+                One of (--minimal, --patience, --histogram)
+                or None if setting is invalid.
+        """
+        return self._DIFF_ALGORITHM.get(self.get('algorithm'))
 
 
 class GitGutterOpenFileCommand(sublime_plugin.ApplicationCommand):


### PR DESCRIPTION
Issue #422 proposes the usage of `git diff --histogram` to determine file modifications.

This commit therefore replaces the "patience" setting by a more general "diff_algorithm". This key can be set to ("default", "minimal", "patience", "histogram") to select the desired diff algorithm. The setting is internally translated to the command line argument to ensure only valid arguments are passed to git.