### PR TITLE
Enhancement: Add command with keybinding to revert changes

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+shift+alt+j"], "command": "git_gutter_next_change" },
     { "keys": ["ctrl+shift+alt+k"], "command": "git_gutter_prev_change" },
+    { "keys": ["ctrl+shift+alt+z"], "command": "git_gutter_revert_change" },
     { "keys": ["ctrl+shift+alt+c", "ctrl+d"], "command": "git_gutter_diff_popup" },
     { "keys": ["ctrl+shift+alt+c", "v"], "command": "git_gutter_show_compare" },
     { "keys": ["ctrl+shift+alt+c", "h"], "command": "git_gutter_compare_head" },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["super+shift+option+j"], "command": "git_gutter_next_change" },
     { "keys": ["super+shift+option+k"], "command": "git_gutter_prev_change" },
+    { "keys": ["super+shift+option+z"], "command": "git_gutter_revert_change" },
     { "keys": ["super+shift+option+c", "super+d"], "command": "git_gutter_diff_popup" },
     { "keys": ["super+shift+option+c", "v"], "command": "git_gutter_show_compare" },
     { "keys": ["super+shift+option+c", "h"], "command": "git_gutter_compare_head" },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+shift+alt+j"], "command": "git_gutter_next_change" },
     { "keys": ["ctrl+shift+alt+k"], "command": "git_gutter_prev_change" },
+    { "keys": ["ctrl+shift+alt+z"], "command": "git_gutter_revert_change" },
     { "keys": ["ctrl+shift+alt+c", "ctrl+d"], "command": "git_gutter_diff_popup" },
     { "keys": ["ctrl+shift+alt+c", "v"], "command": "git_gutter_show_compare" },
     { "keys": ["ctrl+shift+alt+c", "h"], "command": "git_gutter_compare_head" },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,6 +4,10 @@
         "command": "git_gutter_diff_popup"
     },
     {
+        "caption": "GitGutter: Revert Change",
+        "command": "git_gutter_revert_change"
+    },
+    {
         "caption": "GitGutter: Show Comparing Against",
         "command": "git_gutter_show_compare"
     },

--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ There are commands to jump between modifications. The default key bindings for t
  <kbd>Cmd+Shift+Option+j</kbd> | <kbd>Ctrl+Shift+Alt+j</kbd> | Next
 
 
+### Revert Change
+
+The command reverts the text under the first cursor to the state in git. The default key binding for this command is:
+
+ OS X                          | Windows / Linux             | Description
+-------------------------------|-----------------------------|-------------
+ <kbd>Cmd+Shift+Option+z</kbd> | <kbd>Ctrl+Shift+Alt+z</kbd> | Revert
+
+
 ## ⚙ Settings
 
 Settings are accessed via the <kbd>Preferences</kbd> > <kbd>Package Settings</kbd> > <kbd>GitGutter</kbd> menu.

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -10,7 +10,8 @@ from .commands import (
     GitGutterCompareCommitCommand, GitGutterCompareFileCommitCommand,
     GitGutterCompareHeadCommand, GitGutterCompareOriginCommand,
     GitGutterCompareTagCommand, GitGutterNextChangeCommand,
-    GitGutterPrevChangeCommand, GitGutterShowCompareCommand)
+    GitGutterPrevChangeCommand, GitGutterShowCompareCommand,
+    GitGutterRevertChangeCommand)
 from .popup import (
     GitGutterDiffPopupCommand, GitGutterReplaceTextCommand)
 from .settings import (

--- a/modules/commands.py
+++ b/modules/commands.py
@@ -8,6 +8,7 @@ from . import events
 from . import goto
 from . import handler
 from . import popup
+from . import revert
 from . import settings
 from . import show_diff
 from . import utils
@@ -40,7 +41,8 @@ class GitGutterCommand(sublime_plugin.TextCommand):
         'compare_against_head': compare.set_against_head,
         'compare_against_origin': compare.set_against_origin,
         'show_compare': compare.show_compare,
-        'show_diff_popup': popup.show_diff_popup
+        'show_diff_popup': popup.show_diff_popup,
+        'revert_change': revert.revert_change
     }
 
     def __init__(self, *args, **kwargs):
@@ -176,3 +178,8 @@ class GitGutterNextChangeCommand(GitGutterBaseCommand):
 class GitGutterPrevChangeCommand(GitGutterBaseCommand):
     def run(self, edit):
         self.view.run_command('git_gutter', {'action': 'jump_to_prev_change'})
+
+
+class GitGutterRevertChangeCommand(GitGutterBaseCommand):
+    def run(self, edit):
+        self.view.run_command('git_gutter', {'action': 'revert_change'})

--- a/modules/revert.py
+++ b/modules/revert.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+
+def revert_change(git_gutter, **kwargs):
+    """Revert changed hunk under the cursor.
+
+    Arguments:
+        git_gutter (GitGutterCommand):
+            The main command object, which represents GitGutter
+            and called this functiond.
+        kwargs (dict):
+            The arguments passed from GitGutterRevertChangesCommand
+            to GitGutterCommand.
+    """
+    view = git_gutter.view
+    selection = view.sel()
+    if not selection:
+        return
+    point = selection[0].end()
+    # get line number from text point
+    line = view.rowcol(point)[0] + 1
+    revert_change_impl(view, git_gutter.git_handler.diff_line_change(line))
+
+
+def revert_change_impl(view, diff_info):
+    """Revert changes defined by diff_info.
+
+    Arguments:
+        view (sublime.View):
+            The view in which the changes are to revert.
+        diff_info (tuple):
+            All the information required to revert the changes.
+    """
+    del_lines, start, size, meta = diff_info
+    if start == -1:
+        return
+
+    # extract the type of the hunk: removed, modified, (x)or added
+    is_removed = size == 0
+    is_modified = not is_removed and bool(del_lines)
+
+    new_text = '\n'.join(del_lines)
+    # (removed) if there is no text to remove, set the
+    # region to the end of the line, where the hunk starts
+    # and add a new line to the start of the text
+    if is_removed:
+        if start != 0:
+            # set the start and the end to the end of the start line
+            start_point = end_point = view.text_point(start, 0) - 1
+            # add a leading newline before inserting the text
+            new_text = '\n' + new_text
+        else:
+            # (special handling for deleted at the start of the file)
+            # if we are before the start we need to set the start
+            # to 0 and add the newline behind the text
+            start_point = end_point = 0
+            new_text = new_text + '\n'
+    # (modified/added)
+    # set the start point to the start of the hunk
+    # and the end point to the end of the hunk
+    else:
+        start_point = view.text_point(start - 1, 0)
+        end_point = view.text_point(start + size - 1, 0)
+        # (modified) if there is text to insert, we
+        # don't want to capture the trailing newline,
+        # because we insert lines without a trailing newline
+        if is_modified and end_point != view.size():
+            end_point -= 1
+    view.run_command('git_gutter_replace_text', {
+        'start': start_point, 'end': end_point, 'text': new_text})


### PR DESCRIPTION
With GitGutter's diff popup a user can revert a changed hunk to the state of the compared commit.

This commit moves the code to perform the revert operation into a dedicated module and adds it to the internal command chain:

1. Add the revert.py with the implementation moved from popup.factory module
2. Add "revert_change" to command map in the main GitGutterCommand class.

   provides: `view.run_command("git_gutter", {"action": "revert_change"}`

3. Add TextCommand "git_gutter_revert_change" meant for external use.

   provides: `view.run_command("git_gutter_revert_change"}`

4. Add an entry to the Default.sublime-commands
5. Add Ctrl+Shift+Alt+Z key binding.
6. Add a short note to the README.

NOTE: The revert operation does not work with multiple cursors at the moment.

---

Resolves #440