### PR TITLE
Fix: Compare against Origin (Issue #371)

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -26,6 +26,7 @@
   // Valid constants are:
   // "HEAD":   Compare against most recent commit
   // "master": Compare against master branch
+  // "master@{upstream}": Compare against remote master branch
   "compare_against": "HEAD",
 
   // Live mode evaluates changes every time file is modified,

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The following options are available:
 - Compare against particular tag
 - Compare against specific commit
 - Compare against specific file commit (current file's history)
-- Compare against origin
+- Compare against origin (@{upstream})
 
 To change the compare option:
 

--- a/modules/compare.py
+++ b/modules/compare.py
@@ -179,7 +179,7 @@ def set_against_origin(git_gutter, **kwargs):
     def on_branch_name(branch_name):
         if branch_name:
             git_gutter.git_handler.set_compare_against(
-                'origin/%s' % branch_name, True)
+                '%s@{upstream}' % branch_name, True)
 
     git_gutter.git_handler.git_current_branch().then(on_branch_name)
 


### PR DESCRIPTION
Closes: #371

This PR changes the "Compare against Origin" function to store `<branch_name>@{upstream}` as compare target instead of `origin/<branch_name>` which might not have been useful in all use cases.

This modification enables a user to compare against the upstream revision of each currently checked out branch.

The command name an the title are not modified for backward compatibility reasons.

If the local branch doesn't have a tracked remote branch, each file is displayed as `inserted`.