### PR TITLE
Enhancement: Use shellenv library to help finding git on Linux/MacOS.

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -2,14 +2,16 @@
     "*": {
         "*": [
             "markupsafe",
-            "python-jinja2"
+            "python-jinja2",
+            "shellenv"
         ],
         ">=3119": [
             "pygments",
             "python-markdown",
             "mdpopups",
             "python-jinja2",
-            "markupsafe"
+            "markupsafe",
+            "shellenv"
         ]
     }
 }

--- a/modules/handler.py
+++ b/modules/handler.py
@@ -14,6 +14,12 @@ except ImportError:
         pass
     _HAVE_TIMEOUT = False
 
+try:
+    import shellenv
+    _, SHELL_ENV = shellenv.get_env(for_subprocess=True)
+except ImportError:
+    SHELL_ENV = None
+
 import sublime
 
 from . import path
@@ -747,7 +753,7 @@ class GitGutterHandler(object):
             proc = subprocess.Popen(
                 args=args, cwd=self._git_tree, startupinfo=startupinfo,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                stdin=subprocess.PIPE)
+                stdin=subprocess.PIPE, env=SHELL_ENV)
             if _HAVE_TIMEOUT:
                 stdout, stderr = proc.communicate(timeout=30)
             else:

--- a/modules/support.py
+++ b/modules/support.py
@@ -11,6 +11,13 @@ import textwrap
 import sublime
 import sublime_plugin
 
+try:
+    import shellenv
+    _, SHELL_ENV = shellenv.get_env(for_subprocess=True)
+except ImportError:
+    SHELL_ENV = None
+
+
 # get absolute path of the package
 PACKAGE_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if os.path.isfile(PACKAGE_PATH):
@@ -32,7 +39,7 @@ def git(*args):
         startupinfo = None
     proc = subprocess.Popen(
         args=['git'] + [arg for arg in args], startupinfo=startupinfo,
-        stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE, stdin=subprocess.PIPE, env=SHELL_ENV,
         # run command in package directory if exists.
         cwd=PACKAGE_PATH if os.path.isdir(PACKAGE_PATH) else None)
     stdout, _ = proc.communicate()


### PR DESCRIPTION
This PR adds an optional import of 'shellenv' library to read environment variables from a user's login shell to be used for git execution.

As a result GitGutter always runs the git binary also seen by the login shell. This change should hopefully help preventing issues on Linux or especially OSX with git binary not being found or wrong version being used.

GitGutter should work without https://github.com/int3h/SublimeFixMacPath now.

Can someone with a Mac check, whether it really works and if it is useful to add this commit to GitGutter?