### PR TITLE
Enhancement: Add count and wrap arguments to goto commands. (Issue #458)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,22 @@ The commands are used to quickly navigate between modifications. The default key
  <kbd>Cmd+Shift+Option+k</kbd> | <kbd>Ctrl+Shift+Alt+k</kbd> | Goto Previous Change
  <kbd>Cmd+Shift+Option+j</kbd> | <kbd>Ctrl+Shift+Alt+j</kbd> | Goto Next Change
 
+The commands use `"next_prev_change_wrap"` setting by default to decide whether to continue at document boundaries. This behavior and the step size can be customized by command arguments with values other then `None`.
+
+#### Example
+
+```JavaScript
+{ "command": "git_gutter_prev_change", "args": {"count": 2, "wrap": False} },
+{ "command": "git_gutter_next_change", "args": {"count": 2, "wrap": False} }
+```
+
+#### Arguments
+
+arg     | valid range       | description
+:------:|:-----------------:|-----------------------------------------------
+count   | None, >=1         | number of iterations to find destination hunk
+wrap    | None, False, True | enable/disable wrapping at document boundaries
+
 
 ### Copy Content from Commit
 

--- a/modules/goto.py
+++ b/modules/goto.py
@@ -5,36 +5,65 @@ def next_change(git_gutter, **kwargs):
     """Move cursor to the beginning of the next changed hunk.
 
     Arguments:
-        git_gutter (GitGutterCommand): The main command object, which
-            represents GitGutter.
-        kwargs (dict): The arguments received from the `run_command`.
+        git_gutter (GitGutterCommand):
+            The main command object, which represents GitGutter.
+        kwargs (dict):
+            The arguments received from the `run_command`.
             This argument is declared to create a common interface being used
             by the GitGutterCommand object.
+
+    Valid kwargs are:
+        count (int):
+            The number of calls to jump_func to determine the destination.
+            Defaults to 1 if the argument is missing or invalid.
+        wrap (bool):
+            If False, stop searching for the next hunk at document boundaries,
+            continue otherwise. If wrap is None, the 'next_prev_change_wrap'
+            setting is used.
     """
-    _goto_change(git_gutter, _find_next_change)
+    _goto_change(git_gutter, _find_next_change,
+                 kwargs.get('count'), kwargs.get('wrap'))
 
 
 def prev_change(git_gutter, **kwargs):
     """Move cursor to the beginning of the previous changed hunk.
 
     Arguments:
-        git_gutter (GitGutterCommand): The main command object, which
-            represents GitGutter.
-        kwargs (dict): The arguments received from the `run_command`.
+        git_gutter (GitGutterCommand):
+            The main command object, which represents GitGutter.
+        kwargs (dict):
+            The arguments received from the `run_command`.
             This argument is declared to create a common interface being used
             by the GitGutterCommand object.
+
+    Valid kwargs are:
+        count (int):
+            The number of calls to jump_func to determine the destination.
+            Defaults to 1 if the argument is missing or invalid.
+        wrap (bool):
+            If False, stop searching for the next hunk at document boundaries,
+            continue otherwise. If wrap is None, the `next_prev_change_wrap`
+            setting is used.
     """
-    _goto_change(git_gutter, _find_prev_change)
+    _goto_change(git_gutter, _find_prev_change,
+                 kwargs.get('count'), kwargs.get('wrap'))
 
 
-def _goto_change(git_gutter, jump_func):
+def _goto_change(git_gutter, jump_func, count, wrap):
     """Get a tuple of changes and goto the next one found by jump_func.
 
     Arguments:
-        git_gutter (GitGutterCommand): The main command object, which
-            represents GitGutter.
-        jump_func (function): The function to use to select the next hunk from
-            the list of changes.
+        git_gutter (GitGutterCommand):
+            The main command object, which represents GitGutter.
+        jump_func (function):
+            The function to use to select the next hunk from the list of changes.
+        count (int):
+            The number of calls to jump_func to determine the destination.
+            Defaults to 1 if the argument is missing or invalid.
+        wrap (bool):
+            If False, stop searching for the next hunk at document boundaries,
+            continue otherwise. If wrap is None, the `next_prev_change_wrap`
+            setting is used.
     """
     selections = git_gutter.view.sel()
     if not selections:
@@ -42,9 +71,13 @@ def _goto_change(git_gutter, jump_func):
     changes = git_gutter.git_handler.diff_changed_blocks()
     if not changes:
         return
-    current_row, _ = git_gutter.view.rowcol(selections[0].begin())
-    wrap = git_gutter.settings.get('next_prev_change_wrap', True)
-    line = jump_func(changes, current_row + 1, wrap)
+    if not isinstance(wrap, bool):
+        wrap = git_gutter.settings.get('next_prev_change_wrap', True)
+    if not isinstance(count, int) or count < 1:
+        count = 1
+    line = git_gutter.view.rowcol(selections[0].begin())[0] + 1
+    for i in range(count):
+        line = jump_func(changes, line, wrap)
     git_gutter.view.run_command("goto_line", {"line": line})
 
 
@@ -52,9 +85,12 @@ def _find_next_change(changes, current_row, wrap):
     """Find the next line after current row in changes.
 
     Arguments:
-        changes (list): The list of first lines of changed hunks.
-        current_row (int): The row to start searching from.
-        wrap (bool): If True continue with first change after end of file.
+        changes (list):
+            The list of first lines of changed hunks.
+        current_row (int):
+            The row to start searching from.
+        wrap (bool):
+            If True continue with first change after end of file.
 
     Returns:
         int: The next line in changes.
@@ -68,9 +104,12 @@ def _find_prev_change(changes, current_row, wrap):
     """Find the previous line before current row in changes.
 
     Arguments:
-        changes (list): The list of first lines of changed hunks.
-        current_row (int): The row to start searching from.
-        wrap (bool): If True continue with first change after end of file.
+        changes (list):
+            The list of first lines of changed hunks.
+        current_row (int):
+            The row to start searching from.
+        wrap (bool):
+            If True continue with first change after end of file.
 
     Returns:
         int: The previous line in changes.


### PR DESCRIPTION
This commit adds the arguments

- count  - number of iterations to find destination hunk
- wrap   - enable/disable wrapping at document boundaries

to the text commands:

- git_gutter_prev_change
- git_gutter_next_change

This change improves support for NeoVintageous package, but adds no new commands/functions to be executed directly.