### PR TITLE
Added new SublimeLinter protected regions key

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -118,6 +118,7 @@
     "protected_regions": [
         "sublimelinter-warning-gutter-marks",
         "sublimelinter-error-gutter-marks",
+        "sublime_linter.protected_regions",
         "bookmarks",
         "lsp_error",
         "lsp_warning",


### PR DESCRIPTION
A big update is coming to SublimeLinter, in which wake the default key has been changed.
See:
https://github.com/SublimeLinter/SublimeLinter3/pull/665

Old keys:
```
        "sublimelinter-warning-gutter-marks",
        "sublimelinter-error-gutter-marks",
```

Those old keys may still remain in there for a while after the rollout.
We are going to open another PR at a point in the future to remove those old keys.