### PR TITLE
Enhancement: Add support for custom environment variables

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -18,6 +18,18 @@
     //   },
     "git_binary": "",
 
+    // Additional environment variables to pass to git.
+    // This list is merged with the global set of environment variables
+    // provided by Sublime Text.
+    //
+    // Note:
+    // 1. Keys with value `None` are removed from the global environment.
+    // 2. If this dictionary is defined per view or project it is used
+    //    exclusively! It won't be merged with the global settings.
+    "env": {
+        "GIT_OPTIONAL_LOCKS": 0
+    },
+
     // The commit, branch, tag, or remote to compare against.
     // This setting changes the initial compare target and can
     // be temporarily overwritten by 'Compare against ...' commands

--- a/Preferences.sublime-settings-hints
+++ b/Preferences.sublime-settings-hints
@@ -26,6 +26,18 @@
     //   },
     "git_binary": "",
 
+    // Additional environment variables to pass to git.
+    // This list is merged with the global set of environment variables
+    // provided by Sublime Text.
+    //
+    // Note:
+    // 1. Keys with value `None` are removed from the global environment.
+    // 2. If this dictionary is defined per view or project it is used
+    //    exclusively! It won't be merged with the global settings.
+    "git_gutter_env": {
+        "GIT_OPTIONAL_LOCKS": 0
+    },
+
     // The commit, branch, tag, or remote to compare against.
     // This setting changes the initial compare target and can
     // be temporarily overwritten by 'Compare against ...' commands


### PR DESCRIPTION
The primary reason to add custom environment variables support is git adding some useful variables like GIT_OPTIONAL_LOCKS which can/will be used to optimize git runtime behavior without causing older versions to fail due to unsupported command line arguments.

In some cases being able to add/manipulate the environment might help fixing some edge cases.