### PR TITLE
Fix: mangled {{branch}} text when `git status` output is colored (Issue #474)

### DIFF
--- a/modules/handler.py
+++ b/modules/handler.py
@@ -721,6 +721,7 @@ class GitGutterHandler(object):
 
         args = [
             self.settings.git_binary,
+            '-c', 'color.status=never',
             'status', '-b', '-s', '-u'
         ]
         return self.execute_async(args).then(parse_output)


### PR DESCRIPTION
* add "-c color.status=never" option to `git status`, definitively disabling color output

### Discussion

{{branch}} is mis-parsed if `git status` output is colored (eg, when `git` is configured
with "config.status=always"). Using the "-c color.status=never" option overrides any user
configuration, displaying `git status` as uncolored in all cases and fixing the issue.

Notably, option ordering is important in this instance. The "-c ..." option is a `git`
base option, not a `git status` subcommand option. So, as done here, it must be inserted
before the "status" subcommand.

ref: Issue #474 