### PR TITLE
Enhancement: Add protected regions for diff popup (Issue #476)

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -137,6 +137,12 @@
         "lsp_info"
     ],
 
+    // Do not show the Diff Popup if a line contains these regions
+    // Useful for making sure GitGutter does not fight with other popups.
+    "diff_popup_protected_regions": [
+        "sublime_linter.protected_regions"
+    ],
+
     // The gutter theme defines the icons to show for the different events.
     "theme": "Default.gitgutter-theme"
 }

--- a/Preferences.sublime-settings-hints
+++ b/Preferences.sublime-settings-hints
@@ -145,6 +145,12 @@
         "lsp_info"
     ],
 
+    // Do not show the Diff Popup if a line contains these regions
+    // Useful for making sure GitGutter does not fight with other popups.
+    "git_gutter_diff_popup_protected_regions": [
+        "sublime_linter.protected_regions"
+    ],
+
     // The gutter theme defines the icons to show for the different events.
     "git_gutter_theme": "Default.gitgutter-theme"
 }

--- a/README.md
+++ b/README.md
@@ -367,6 +367,20 @@ The popup uses the [mdpopups](https://github.com/facelessuser/sublime-markdown-p
 
 👉 User style settings are accessible via the settings menu.
 
+#### Diff Popup Protected Regions
+
+```
+"diff_popup_protected_regions": [
+  "sublime_linter.protected_regions"
+],
+```
+
+To avoid GitGutter's diff popup from figting with other popups while hovering the gutter a list of protected regions can be created. If the line under the mouse cursor is occupied by one of these regions, no diff popup is displayed.
+
+👉 You will need to figure out the names of the regions to protect.
+
+👉 You can still open the diff popup via key binding or command pallet.
+
 
 #### Untracked Files
 

--- a/modules/events.py
+++ b/modules/events.py
@@ -105,8 +105,16 @@ class EventListener(sublime_plugin.EventListener):
         key = view.id()
         if key not in self.view_events:
             return
-        if not self.view_events[key].settings.get('enable_hover_diff_popup'):
+        # check if hover is enabled
+        settings = self.view_events[key].settings
+        if not settings.get('enable_hover_diff_popup'):
             return
+        # check protected regions
+        keys = tuple(settings.get('diff_popup_protected_regions'))
+        points = (view.line(reg).a for key in keys for reg in view.get_regions(key))
+        if point in points:
+            return
+        # finally show the popup
         view.run_command('git_gutter_diff_popup', {
             'point': point, 'flags': sublime.HIDE_ON_MOUSE_MOVE_AWAY})
 


### PR DESCRIPTION
This PR adds support to ignore the hover event if a line is occupied by a certain region. The diff popup is not displayed by hovering such lines, but still can be opened by key binding or command pallet.

This enhancement is meant to improve compatibility with other packages.