### PR TITLE
Enhancement: Place all temporary files into a dedicated sub directory.

### DIFF
--- a/modules/tempfile.py
+++ b/modules/tempfile.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+
+# The folder to place all temporary files into.
+TEMP_DIR = os.path.join(tempfile.tempdir, "GitGutter")
+
+
+class TempFile(object):
+    """A temporary file object which allows shared reading.
+
+    All the temporary files created by the `tempfile` module's functions are
+    accessible by the calling process only on some operating systems.
+    Therefore this class represents a file which is deleted as soon as the
+    object is destroyed but without keeping the file open all the time.
+    """
+
+    def __init__(self, mode='r'):
+        """Initialize TempFile object."""
+        try:
+            os.mkdir(TEMP_DIR)
+        except FileExistsError:
+            pass
+        self.name = tempfile.mktemp(dir=TEMP_DIR)
+        self._mode = mode
+        self._file = None
+        # Cache unlink to keep it available even though the 'os' module is
+        # already None'd out whenever __del__() is called.
+        # See python stdlib's tempfile.py for details.
+        self._unlink = os.unlink
+
+    def __del__(self):
+        """Destroy the TempFile object and remove the file from disk."""
+        self.close()
+        try:
+            self._unlink(self.name)
+        except OSError:
+            pass
+
+    def __enter__(self):
+        """`With` statement support."""
+        return self.open()
+
+    def __exit__(self, exc, value, tb):
+        """`With` statement support."""
+        self.close()
+
+    def open(self):
+        """Open temporary file."""
+        if self._file is None:
+            self._file = open(self.name, mode=self._mode)
+        return self._file
+
+    def close(self):
+        """Close temporary file."""
+        if self._file is not None:
+            self._file.close()
+            self._file = None


### PR DESCRIPTION
Fixes issue #483

Introduces the `TempFile` class to handle access to temporary files and to ensure file deletion.

A look into python's tempfile module revealed a possible issue with temporary files not being removed on unix/linux/mac if `os.unlink()` is called within the `__del__()` method of an object. The `os` module might no longer exist at the point of time the `__del__()` is called especially upon application shutdown.

To ensure the files to be deleted, it is required to cache the `os.unlink()` function within the `TempFile` class and call the cached one within `__del__()`.

I don't have a Linux by hand at the time, so I'd ask for someone to test the new class on Linux and MacOS for a while to check whether file deletion works more reliable now.

The goal is not to keep any temporary file behind, after all ST instances are closed.