### PR TITLE
Fix README documentation for `diff_algorithm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ With the `"env"` dictionary custom environment variables can be passed to git. T
 
 `"diff_algorithm": "patience"`
 
-GitGutter uses the "patience" diff algorithm by default. Set `diff_algorithm` to one of the follwoing values to change this behavior.
+Set `diff_algorithm` to one of the following values to change this behavior.
 
 value       | description
 :----------:|-----------------------------------------------


### PR DESCRIPTION
The actual default is `default`, so the readme shouldn't claim it's `patience`. It's already documented in the description table, so there's no need to mention it twice.

Also fixed a typo.