### PR TITLE
Add WSL support

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -2,13 +2,19 @@
 // Default values for GitGutter.sublime-settings
 //
 {
-    // Custom path to git binary when not in PATH.  An empty string will search
-    // PATH for "git".  The setting may be a direct string to a git binary, e.g.:
+    // CUSTOM PATH TO GIT BINARY.
+    // An empty string will search the PATH environment for "git".
+    //
+    //   "git_binary": "",
+    //
+    // The setting may be a direct string to a git binary.
+    // An unix like path makes git run via Windows Subsystem for Linux
+    // on Windows 10. It fails if WSL is not available.
     //
     //   "git_binary": "/usr/bin/git",
     //
     // Or it may be a dictionary keyed off what sublime.platform() returns,
-    // so it may be customized on a per-platform basis.  e.g.:
+    // so it may be customized on a per-platform basis.
     //
     //   "git_binary": {
     //       "default": "",

--- a/Preferences.sublime-settings-hints
+++ b/Preferences.sublime-settings-hints
@@ -10,13 +10,19 @@
 // GitGutter.sublime-settings is used to store package settings as well.
 //
 {
-    // Custom path to git binary when not in PATH.  An empty string will search
-    // PATH for "git".  The setting may be a direct string to a git binary, e.g.:
+    // CUSTOM PATH TO GIT BINARY.
+    // An empty string will search the PATH environment for "git".
+    //
+    //   "git_binary": "",
+    //
+    // The setting may be a direct string to a git binary.
+    // An unix like path makes git run via Windows Subsystem for Linux
+    // on Windows 10. It fails if WSL is not available.
     //
     //   "git_binary": "/usr/bin/git",
     //
     // Or it may be a dictionary keyed off what sublime.platform() returns,
-    // so it may be customized on a per-platform basis.  e.g.:
+    // so it may be customized on a per-platform basis.
     //
     //   "git_binary": {
     //       "default": "",

--- a/README.md
+++ b/README.md
@@ -411,10 +411,25 @@ GitGutter shows diffs in the minimap on Sublime Text 3 by default. Change `show_
 
 `"git_binary": ""`
 
-If `git` is not found on [PATH](https://en.wikipedia.org/wiki/PATH_(variable)) by GitGutter the `git_binary` setting can be set to the location of the git binary. The value may be either a direct string to a git binary:
+GitGutter looks for the git binary in the [PATH](https://en.wikipedia.org/wiki/PATH_(variable)) environment variable by default.
+
+The setting can be used to
+
+1. specify the path to a custom git installation which is not registered to [PATH](https://en.wikipedia.org/wiki/PATH_(variable)).
+2. run git via **W**indows **S**ubsystem for **L**inux (WSL) on Windows 10 by setting up a unix like path.
+
+The value may be either a direct string to a git binary:
+
+_Windows:_
 
 ```JavaScript
 "git_binary": "E:\\Portable\\git\\bin\\git.exe"
+```
+
+_Linux/OSX/WSL:_
+
+```JavaScript
+"git_binary": "/usr/bin/git"
 ```
 
 or it may be a dictionary keyed off what sublime.platform() returns, so it may be customized on a per-platform basis:

--- a/modules/commands.py
+++ b/modules/commands.py
@@ -26,7 +26,8 @@ DISABLED_REASON = {
     6: 'view is a REPL',
     7: 'view encoding is Hexadecimal',
     8: 'file not in a working tree',
-    9: 'git is not working'
+    9: 'git is not working',
+    10: 'UNC paths not supported by WSL'
 }
 
 
@@ -94,6 +95,9 @@ class GitGutterCommand(sublime_plugin.TextCommand):
             # Keep quite if git is not working properly
             elif not self.git_handler.version(validate):
                 state = 9
+            # In WSL mode the repo must be located on a drive like (C:\path)
+            elif not self.git_handler.work_tree_supported():
+                state = 10
 
         # Handle changed state
         valid = state == 0

--- a/modules/compare.py
+++ b/modules/compare.py
@@ -22,7 +22,7 @@ def set_against_commit(git_gutter, **kwargs):
             return sublime.message_dialog('No commits found in repository.')
 
         # Create the list of commits to show in the quick panel
-        items = [r.split('\a') for r in output.split('\n')]
+        items = [r.strip('"').split('\a') for r in output.split('\n')]
 
         def on_done(index):
             """Select new compare target according to user selection."""
@@ -58,7 +58,8 @@ def set_against_file_commit(git_gutter, **kwargs):
         # Sort items by author date in reversed order,
         # split each line by \a and strip time stamp from beginning
         items = [
-            r.split('\a')[1:] for r in sorted(output.split('\n'), reverse=True)
+            r.strip('"').split('\a')[1:]
+            for r in sorted(output.split('\n'), reverse=True)
         ]
 
         def on_done(index):
@@ -93,7 +94,7 @@ def set_against_branch(git_gutter, **kwargs):
 
         def parse_result(result):
             """Create a quick panel item for one line of git's output."""
-            branch, commit, name, date = result.split('\a')
+            branch, commit, name, date = result.strip('"').split('\a')
             branch = branch[11:]   # skip 'refs/heads/'
             return [branch, commit, name, date]
 
@@ -132,7 +133,7 @@ def set_against_tag(git_gutter, **kwargs):
 
         def parse_result(result):
             """Create a quick panel item for one line of git's output."""
-            tag, commit, tname, tdate, cname, cdate = result.split('\a')
+            tag, commit, tname, tdate, cname, cdate = result.strip('"').split('\a')
             tag = tag[10:]         # skip 'refs/heads/'
             return [tag, commit, tname.strip() or cname, tdate.strip() or cdate]
 

--- a/modules/path.py
+++ b/modules/path.py
@@ -92,3 +92,26 @@ def split_work_tree(file_path):
                     file_path, path).replace('\\', '/'))
             path, name = os.path.split(path)
     return (None, None)
+
+
+def translate_to_wsl(path):
+    """Translate a windows path to unix path for WSL.
+
+    WSL stands for Windows Subsystem for Linux and allows to run native linux
+    programs on windows. In order to access Windows' filesystem the local
+    drives are mounted to /mnt/<Drive> within the WSL shell. This little helper
+    function maps a windows path to such a WSL compatible unix path in order
+    to run WSL commands seemlessly.
+
+    Note:
+        This function works for local files only at the moment.
+
+    Arguments:
+        path (string): the windows path to translate to unix path
+
+    Returns
+        string: the unix path to be used by calls to programs running on WSL
+    """
+    if path[1] != ':':
+        raise FileNotFoundError("UNC paths are not supported by WSL!")
+    return '/mnt/{0}{1}'.format(path[0].lower(), path[2:].replace('\\', '/'))

--- a/modules/promise.py
+++ b/modules/promise.py
@@ -3,6 +3,16 @@ import functools
 import threading
 
 
+class PromiseError(Exception):
+    """A failed Promise is to be resolved with this PromiseError.
+
+    Normal errors and exceptions can't be catched by the applicaiton due to
+    multithreading. Therefore a function should return PromiseError to indicate
+    a failure to be handled by `.then()`
+    """
+    pass
+
+
 class Promise(object):
     """A simple implementation of the Promise specification.
 

--- a/modules/temp.py
+++ b/modules/temp.py
@@ -94,3 +94,6 @@ class TempFile(object):
         if self._file is not None:
             self._file.close()
             self._file = None
+
+    def tell(self):
+        return self._file.tell()


### PR DESCRIPTION
Closes #500 

This PR introduces support for Windows Subsystem for Linux (WSL).

It uses the _wsl.exe_ and was tested on Windows 10 x64 (1803) with openSUSE Leap 42 running git 2.13. 
Won't fix issues with earlier Windows builds!

#### Setup

To enable WSL just add an unix like path to the `git_binary` setting.

```
    "git_binary": "/usr/bin/git",
```


#### Known Issues

1. WSL is slow. git via WSL needs 2 to 3 times longer to answer then git for Windows.
2. WSL occasionally truncates large outputs when read via `stdout`.

The later one is worked around by passing the output of `git cat-file` directly to the open file stream of the cache file (see 8b38a70). This was the most critical part as the committed file content is only read once. The output of `git diff` might still be truncated sometimes if it contains too many changes, but should show the correct result after the next modification (hopefully).

#### Remarks

The required changes to introduce the feature are added as separate commits.