### PR TITLE
Add option to ignore whitespace changes when blaming in line annotations

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -154,6 +154,14 @@
     //   ...
     "line_annotation_ruler": false,
 
+    // (ST3, Build 3124+ only)
+    // Whether to ignore whitespace changes when showing line annotations.
+    //
+    // Valid values are:
+    //   false  -- don't ignore whitespace changes (default)
+    //   true   -- ignore whitespace changes
+    "line_annotation_ignore_whitespace": false,
+
     // LINE ANNOTATION TEXT TEMPLATE
     // If the value is an array it is joined to a single string and passed to
     // jinja2 template engine (if available) to render the blame message text.

--- a/modules/handler.py
+++ b/modules/handler.py
@@ -678,12 +678,18 @@ class GitGutterHandler(object):
 
     def git_blame(self, row):
         """Call git blame to find out who changed a specific line of code"""
+        if self.settings.get('line_annotation_ignore_whitespace'):
+            ignore_ws = ['-w']
+        else:
+            ignore_ws = []
+
         return self.execute_async([
             self._git_binary,
             '-c', 'core.autocrlf=input',
             '-c', 'core.eol=lf',
             '-c', 'core.safecrlf=false',
-            'blame', '-p', '-L%d,%d' % (row + 1, row + 1),
+            'blame', '-p', '-L%d,%d' % (row + 1, row + 1)
+        ] + ignore_ws + [
             '--contents', self.translate_path_to_wsl(self.view_cache.name),
             '--', self._git_path
         ])


### PR DESCRIPTION
Adds a new setting `line_annotation_ignore_whitespace` which controls passing `-w` to `git blame`. This is great if you have a repo where you want to ignore a commit has changed a bunch of whitespace (see [Git's docs about the option](https://git-scm.com/docs/git-blame#git-blame--w)).