### PR TITLE
Enhancement: line annotation display events

### DIFF
--- a/modules/events.py
+++ b/modules/events.py
@@ -280,30 +280,34 @@ class BlameEventListener(sublime_plugin.EventListener):
     def _run_blame(self, view, force):
         """Run blame if the caret moves to another row."""
 
-        # check if caret is present
-        selection = view.sel()
-        if not selection:
-            return
-
-        # do nothing if row didn't change
-        row, _ = view.rowcol(selection[0].begin())
-        if not force and row == self.last_blame_row.get(view.id(), -1):
-            return
-        self.last_blame_row[view.id()] = row
-
         # remove existing phantoms
         erase_line_annotation(view)
-
-        # ignore empty lines
-        if not view.line(view.text_point(row, 0)):
-            return
 
         # initiate debounce timer
         blame_time = time.time()
         self.latest_blame_time = blame_time
 
         def on_time():
-            if self.latest_blame_time == blame_time:
+            if self.latest_blame_time != blame_time:
+                return
+            try:
+                sel = view.sel()
+                # do nothing if not exactly one cursor is visible
+                if len(sel) != 1:
+                    return
+                sel = sel[0]
+                # do nothing is selection not empty or line is empty
+                if not sel.empty() or not view.line(sel.b):
+                    return
+                row, _ = view.rowcol(sel.b)
+                # do nothing if row didn't change
+                if not force and row == self.last_blame_row.get(view.id(), -1):
+                    return
+                self.last_blame_row[view.id()] = row
+            except (AttributeError, IndexError, TypeError):
+                pass
+            else:
                 view.run_command('git_gutter_blame')
+
         # don't call blame if selected row changes too quickly
         sublime.set_timeout(on_time, 400)


### PR DESCRIPTION
This commit makes some changes to the event handler, which is responsible to
call git blame and display line annotations.

The origin for the changes is issue #528. Even though the issue could not be
reproduced on Windows a couple possible enhancements were identified.

Fixes

1. Fail silently if the active row can't be identified because of an invalid
   or empty selection object returned by ST API.

Enhancements:

1. Hide line annotation if...
   a) multiple cursors are active
   b) selection is not empty
   c) caret is moved vertically in row

   As a result line annotation is displayed only if a single cursor is moved
   to a new unmodified line of text, if word wrap is disabled.

   This should help improving the editing experience and reduce the impact of
   some of the phantoms' drawbacks / limitations.

2. All checks are performed within the debounced code to avoid the line
   annotation to flicker up if text is selected via mouse.