### PR TITLE
Make EasyClangComplete regions protected by default

### DIFF
--- a/GitGutter.sublime-settings
+++ b/GitGutter.sublime-settings
@@ -90,7 +90,8 @@
         "bookmarks",
         "lsp_error",
         "lsp_warning",
-        "lsp_info"
+        "lsp_info",
+        "ecc"
     ],
 
     // Show GitGutter information in the minimap


### PR DESCRIPTION
Added protection for the gutter of [EasyClangComplete](https://packagecontrol.io/packages/EasyClangComplete) by default.