### PR TITLE
Don't use extenral diff tool when performing diff

### DIFF
--- a/modules/handler.py
+++ b/modules/handler.py
@@ -390,7 +390,7 @@ class GitGutterHandler(object):
             '-c', 'core.autocrlf=input',
             '-c', 'core.eol=lf',
             '-c', 'core.safecrlf=false',
-            'diff', '-U0', '--no-color', '--no-index',
+            'diff', '-U0', '--no-color', '--no-index', '--no-ext-diff',
             self.settings.ignore_whitespace,
             self.settings.diff_algorithm,
             self.translate_path_to_wsl(self._git_temp_file.name),


### PR DESCRIPTION
GitGutter simply doesn't work when any external diff tool is in use.

This PR makes sure that GitGutter operations take place with the external diff tool disabled. 